### PR TITLE
Default configuration.

### DIFF
--- a/lib/librato/rack.rb
+++ b/lib/librato/rack.rb
@@ -10,7 +10,7 @@ module Librato
   end
 
   def self.tracker
-    @tracker ||= Librato::Rack::Tracker.new
+    @tracker ||= Librato::Rack::Tracker.new(Librato::Rack::Configuration.new)
   end
 end
 


### PR DESCRIPTION
Librato::Rack::Tracker.new requires a configuration object to be passed.
