### PR TITLE
Introduce wobble in start times

### DIFF
--- a/test/unit/rack/worker_test.rb
+++ b/test/unit/rack/worker_test.rb
@@ -20,6 +20,17 @@ module Librato
       def test_start_time
         worker = Worker.new
 
+        20.times do
+          time = Time.now
+          start = worker.start_time(60)
+          assert start >= time + 1, 'should be more than 1 second from when run'
+          assert start <= time + 120, 'should not be more than 60 seconds from when run'
+        end
+      end
+
+      def test_start_time_with_sync
+        worker = Worker.new(sync: true)
+
         time = Time.now
         start = worker.start_time(60)
         assert start >= time + 60, 'should be more than 60 seconds from when run'


### PR DESCRIPTION
Even out which clock second we tick on instead of syncing to the beginning of each minute by default.

Support old behavior via an instance config option in case we need it for testing later.
