### PR TITLE
Add support for float-style request-start headers

### DIFF
--- a/lib/librato/rack.rb
+++ b/lib/librato/rack.rb
@@ -103,13 +103,13 @@ module Librato
     def record_header_metrics(env)
       queue_start = env['HTTP_X_REQUEST_START'] || env['HTTP_X_QUEUE_START']
       if queue_start
-        queue_start = queue_start.to_s.gsub('t=', '').to_i
-        case queue_start.to_s.length
+        queue_start = queue_start.to_s.sub('t=', '').sub('.', '')
+        case queue_start.length
         when 16 # microseconds
-          wait = ((Time.now.to_f * 1000000).to_i - queue_start) / 1000.0
+          wait = ((Time.now.to_f * 1000000).to_i - queue_start.to_i) / 1000.0
           tracker.timing 'rack.request.queue.time', wait
         when 13 # milliseconds
-          wait = (Time.now.to_f * 1000).to_i - queue_start
+          wait = (Time.now.to_f * 1000).to_i - queue_start.to_i
           tracker.timing 'rack.request.queue.time', wait
         end
       end

--- a/test/apps/queue_wait.ru
+++ b/test/apps/queue_wait.ru
@@ -23,6 +23,9 @@ class QueueWait
     when '/with_t'
       env['HTTP_X_REQUEST_START'] = "t=#{(Time.now.to_f * 1000000).to_i}".to_s
       sleep 0.02
+    when '/with_period'
+      env['HTTP_X_REQUEST_START'] = "%10.3f" % Time.now.to_f
+      sleep 0.025
     end
     @app.call(env)
   end

--- a/test/integration/queue_wait_test.rb
+++ b/test/integration/queue_wait_test.rb
@@ -52,6 +52,14 @@ class QueueWaitTest < Minitest::Test
     assert_in_delta 20, aggregate["rack.request.queue.time"][:sum], 4
   end
 
+  def test_with_period
+    get '/with_period'
+
+    assert_equal 1, aggregate["rack.request.queue.time"][:count],
+      'should track total queue time'
+    assert_in_delta 25, aggregate["rack.request.queue.time"][:sum], 4
+  end
+
   private
 
   def aggregate


### PR DESCRIPTION
Support float-notation values for `X-Request-Start` and `X-Queue-Start`.
