### PR TITLE
Introduce concept of configurable metric suites.

### DIFF
--- a/lib/librato/rack/configuration.rb
+++ b/lib/librato/rack/configuration.rb
@@ -85,6 +85,14 @@ module Librato
         fields
       end
 
+      def suites
+        @suites ||= if ENV.has_key?('LIBRATO_SUITES')
+          Suites.new(ENV['LIBRATO_SUITES'])
+        else
+          SuitesExcept.new(ENV['LIBRATO_SUITES_EXCEPT'])
+        end
+      end
+
       private
 
       def check_deprecations
@@ -110,6 +118,22 @@ module Librato
         end
       end
 
+      class Suites
+        attr_reader :fields
+        def initialize(value)
+          @fields = value.to_s.split(/\s*,\s*/).map(&:to_sym)
+        end
+
+        def include?(field)
+          fields.include?(field)
+        end
+      end
+
+      class SuitesExcept < Suites
+        def include?(field)
+          !fields.include?(field)
+        end
+      end
     end
   end
 end

--- a/lib/librato/rack/tracker.rb
+++ b/lib/librato/rack/tracker.rb
@@ -101,6 +101,10 @@ module Librato
         logger.outlet = target
       end
 
+      def suite_enabled?(suite)
+        config.suites.include?(suite.to_sym)
+      end
+
       private
 
       # access to client instance

--- a/test/unit/rack/configuration_test.rb
+++ b/test/unit/rack/configuration_test.rb
@@ -29,6 +29,35 @@ module Librato
         #assert Librato::Rails.explicit_source, 'source is explicit'
       end
 
+      def test_unconfigured_suites_are_on_by_default
+        config = Configuration.new
+        assert config.suites.include?(:abc)
+        assert config.suites.include?(:xyz)
+      end
+
+      def test_suites_configured_by_inclusion
+        ENV['LIBRATO_SUITES'] = 'abc, jkl,prq , xyz'
+        config = Configuration.new
+        [:abc, :jkl, :prq, :xyz].each do |suite|
+          assert config.suites.include?(suite), "expected '#{suite}' to be active"
+        end
+        refute config.suites.include?(:something_else)
+      ensure
+        ENV.delete('LIBRATO_SUITES')
+      end
+
+      def test_suites_configured_by_exclusion
+        ENV['LIBRATO_SUITES_EXCEPT'] = 'abc, jkl,prq , xyz'
+        config = Configuration.new
+
+        [:abc, :jkl, :prq, :xyz].each do |suite|
+          refute config.suites.include?(suite), "expected '#{suite}' to be inactive"
+        end
+        assert config.suites.include?(:something_else)
+      ensure
+        ENV.delete('LIBRATO_SUITES_EXCEPT')
+      end
+
       def test_legacy_env_variable_config
         ENV['LIBRATO_METRICS_USER'] = 'foo@bar.com'
         ENV['LIBRATO_METRICS_TOKEN'] = 'api_key'

--- a/test/unit/rack/tracker_test.rb
+++ b/test/unit/rack/tracker_test.rb
@@ -46,6 +46,17 @@ module Librato
         ENV.delete('LIBRATO_AUTORUN')
       end
 
+      def test_suite_configured
+        ENV['LIBRATO_SUITES'] = 'abc,prq'
+
+        tracker = Tracker.new(Configuration.new)
+        assert tracker.suite_enabled?(:abc)
+        assert tracker.suite_enabled?(:prq)
+        refute tracker.suite_enabled?(:xyz)
+      ensure
+        ENV.delete('LIBRATO_SUITES')
+      end
+
       private
 
       def buffer_lines


### PR DESCRIPTION
I was unsure about some style things. For example -- the little `Suite` objects, should I put them in a separate file (or files)? e.g. `lib/librato/rack/configuration/suites.rb`. I named them as a plural because the only method they expose (other than the attr reader, which could be made private) is `included?`, so it feels like a collection.

See https://github.com/librato/librato-rails/issues/71 for discussion.