### PR TITLE
Configurable metric suites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rvm:
   - ruby-head
   - rbx
 
+before_install:
+  - gem update bundler
+
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version X.X.X
+* Add support for configurable metric suites
+
 ### Version 0.6.0
 * Add support for proxy configuration
 

--- a/README.md
+++ b/README.md
@@ -95,12 +95,15 @@ All three of the metric suites listed above are enabled by default.
 
 The metric suites can be configured via either the `LIBRATO_SUITES` environment variable or the `suites` attributes on the `Librato::Rack::Configuration` object.
 
-    LIBRATO_SUITES="rack,rack_method"  # use only rack and rack_method suites
-    LIBRATO_SUITES="+foo,bar"          # + prefix indicates that you want the default suites plus foo and bar
+    LIBRATO_SUITES="rack,rack_method"  # use ONLY the rack and rack_method suites
+    LIBRATO_SUITES="+foo,+bar"         # + prefix indicates that you want the default suites plus foo and bar
     LIBRATO_SUITES="-rack_status"      # - prefix indicates that you want the default suites removing rack_status
+    LIBRATO_SUITES="+foo,-rack_status" # Use all default suites except for rack_status while also adding foo
     LIBRATO_SUITES="all"               # Enable all suites
     LIBRATO_SUITES="none"              # Disable all suites
     LIBRATO_SUITES=""                  # Use only the default suites (same as if env var is absent)
+
+Note that you should EITHER specify an explict list of suites to enable OR add/subtract individual suites from the default list (using the +/- prefixes). If you try to mix these two forms a `Librato::Rack::InvalidSuiteConfiguration` error will be raised.
 
 ## Custom Measurements
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,25 @@ NOTE: if Heroku idles your application no measurements will be sent until it rec
 
 When using in an evented context set LIBRATO_EVENT_MODE to `'eventmachine'` if using [EventMachine](https://github.com/eventmachine/eventmachine) or `'synchrony'` if using [EM Synchrony](https://github.com/igrigorik/em-synchrony) and/or [Rack::FiberPool](https://github.com/alebsack/rack-fiber_pool). We're interested in maturing this support, so please let us know if you have any issues.
 
+##### Metric Suites
+
+The metrics recorded by `librato-rack` are organized into named metric suites that can be selecitvely enabled/disabled:
+
+* `rack`: The `rack.request.total`, `rack.request.time`, `rack.request.slow`, and `rack.request.queue.time` metrics
+* `rack_status`: All of the `rack.request.status` metrics
+* `rack_method`: All of the `rack.request.method` metrics
+
+All three of the metric suites listed above are enabled by default.
+
+The metric suites can be configured via either the `LIBRATO_SUITES` environment variable or the `suites` attributes on the `Librato::Rack::Configuration` object.
+
+    LIBRATO_SUITES="rack,rack_method"  # use only rack and rack_method suites
+    LIBRATO_SUITES="+foo,bar"          # + prefix indicates that you want the default suites plus foo and bar
+    LIBRATO_SUITES="-rack_status"      # - prefix indicates that you want the default suites removing rack_status
+    LIBRATO_SUITES="all"               # Enable all suites
+    LIBRATO_SUITES="none"              # Disable all suites
+    LIBRATO_SUITES=""                  # Use only the default suites (same as if env var is absent)
+
 ## Custom Measurements
 
 Tracking anything that interests you is easy with Metrics. There are four primary helpers available:

--- a/lib/librato/rack.rb
+++ b/lib/librato/rack.rb
@@ -81,6 +81,7 @@ module Librato
 
       build_record_request_metrics_method
       build_record_header_metrics_method
+      build_record_exception_method
     end
 
     def call(env)
@@ -126,10 +127,6 @@ module Librato
       [response, duration]
     end
 
-    def record_exception(exception)
-      return if config.disable_rack_metrics
-      tracker.increment 'rack.request.exceptions'
-    end
 
     # Dynamically construct :record_request_metrics method based on
     # configured metric suites
@@ -180,6 +177,19 @@ module Librato
         end
       else
         define_singleton_method(:record_header_metrics) do |env|
+          # no-op
+        end
+      end
+    end
+
+    def build_record_exception_method
+      if tracker.suite_enabled?(:rack)
+        define_singleton_method(:record_exception) do |exception|
+          return if config.disable_rack_metrics
+          tracker.increment 'rack.request.exceptions'
+        end
+      else
+        define_singleton_method(:record_exception) do |exception|
           # no-op
         end
       end

--- a/lib/librato/rack.rb
+++ b/lib/librato/rack.rb
@@ -59,10 +59,9 @@ module Librato
     def call(env)
       check_log_output(env) unless @log_target
       @tracker.check_worker
-      request_method = env["REQUEST_METHOD"]
       record_header_metrics(env)
       response, duration = process_request(env)
-      record_request_metrics(response.first, request_method, duration)
+      record_request_metrics(response.first, env["REQUEST_METHOD"], duration)
       response
     end
 

--- a/lib/librato/rack/configuration.rb
+++ b/lib/librato/rack/configuration.rb
@@ -86,6 +86,7 @@ module Librato
         %w{user token log_level source prefix flush_interval source_pids suites}.each do |field|
           fields[field.to_sym] = self.send(field)
         end
+        fields[:metric_suites] = metric_suites.fields
         fields
       end
 

--- a/lib/librato/rack/configuration.rb
+++ b/lib/librato/rack/configuration.rb
@@ -88,7 +88,15 @@ module Librato
 
       def suites
         @suites ||= if ENV.has_key?('LIBRATO_SUITES')
-          Suites.new(ENV['LIBRATO_SUITES'])
+          suites = ENV['LIBRATO_SUITES']
+          case suites.downcase.strip
+          when 'all'
+            SuitesAll.new
+          when 'none'
+            SuitesNone.new
+          else
+            Suites.new(suites)
+          end
         else
           SuitesExcept.new(ENV['LIBRATO_SUITES_EXCEPT'])
         end
@@ -130,11 +138,24 @@ module Librato
         end
       end
 
+      class SuitesAll
+        def include?(value)
+          true
+        end
+      end
+
       class SuitesExcept < Suites
         def include?(field)
           !fields.include?(field)
         end
       end
+
+      class SuitesNone
+        def include?(value)
+          false
+        end
+      end
+
     end
   end
 end

--- a/lib/librato/rack/configuration.rb
+++ b/lib/librato/rack/configuration.rb
@@ -14,6 +14,8 @@ module Librato
     class Configuration
       EVENT_MODES = [:eventmachine, :synchrony]
 
+      DEFAULT_SUITES = [:rack, :rack_method, :rack_status]
+
       attr_accessor :user, :token, :autorun, :api_endpoint, :tracker,
                     :source_pids, :log_level, :log_prefix, :log_target,
                     :disable_rack_metrics, :flush_interval, :proxy, :suites
@@ -96,16 +98,16 @@ module Librato
                              SuitesAll.new
                            when 'none'
                              SuitesNone.new
-                           when /^\+/
-                             SuitesInclude.new(suites[1..-1])
-                           when /^\-/
-                             SuitesExcept.new(suites[1..-1])
                            else
-                             Suites.new(suites)
+                             Suites.new(suites, default_suites)
                            end
       end
 
       private
+
+      def default_suites
+        DEFAULT_SUITES
+      end
 
       def check_deprecations
         %w{USER TOKEN PREFIX SOURCE}.each do |item|

--- a/lib/librato/rack/configuration.rb
+++ b/lib/librato/rack/configuration.rb
@@ -86,6 +86,14 @@ module Librato
         fields
       end
 
+      def suites
+        @suites ||= if ENV.has_key?('LIBRATO_SUITES')
+          Suites.new(ENV['LIBRATO_SUITES'])
+        else
+          SuitesExcept.new(ENV['LIBRATO_SUITES_EXCEPT'])
+        end
+      end
+
       private
 
       def check_deprecations
@@ -111,6 +119,22 @@ module Librato
         end
       end
 
+      class Suites
+        attr_reader :fields
+        def initialize(value)
+          @fields = value.to_s.split(/\s*,\s*/).map(&:to_sym)
+        end
+
+        def include?(field)
+          fields.include?(field)
+        end
+      end
+
+      class SuitesExcept < Suites
+        def include?(field)
+          !fields.include?(field)
+        end
+      end
     end
   end
 end

--- a/lib/librato/rack/configuration.rb
+++ b/lib/librato/rack/configuration.rb
@@ -1,3 +1,5 @@
+
+
 module Librato
   class Rack
     # Holds configuration for Librato::Rack middleware to use.
@@ -127,42 +129,8 @@ module Librato
         end
       end
 
-      class Suites
-        attr_reader :fields
-        def initialize(value)
-          @fields = value.to_s.split(/\s*,\s*/).map(&:to_sym)
-        end
-
-        def include?(field)
-          fields.include?(field)
-        end
-      end
-
-      class SuitesAll
-        def include?(value)
-          true
-        end
-      end
-
-      class SuitesExcept < Suites
-        DEFAULT_SUITES = [:rack]
-
-        def initialize(value)
-          super
-          @fields = DEFAULT_SUITES - @fields
-        end
-
-        def include?(field)
-          fields.include?(field)
-        end
-      end
-
-      class SuitesNone
-        def include?(value)
-          false
-        end
-      end
-
     end
   end
 end
+
+require_relative 'configuration/suites'

--- a/lib/librato/rack/configuration.rb
+++ b/lib/librato/rack/configuration.rb
@@ -145,8 +145,15 @@ module Librato
       end
 
       class SuitesExcept < Suites
+        DEFAULT_SUITES = [:rack]
+
+        def initialize(value)
+          super
+          @fields = DEFAULT_SUITES - @fields
+        end
+
         def include?(field)
-          !fields.include?(field)
+          fields.include?(field)
         end
       end
 

--- a/lib/librato/rack/configuration/suites.rb
+++ b/lib/librato/rack/configuration/suites.rb
@@ -20,7 +20,7 @@ module Librato
       end
 
       class SuitesExcept < Suites
-        DEFAULT_SUITES = [:rack]
+        DEFAULT_SUITES = [:rack, :rack_method, :rack_status]
 
         def initialize(value)
           super

--- a/lib/librato/rack/configuration/suites.rb
+++ b/lib/librato/rack/configuration/suites.rb
@@ -2,33 +2,40 @@ module Librato
   class Rack
     class Configuration
 
+      DEFAULT_SUITES = [:rack, :rack_method, :rack_status]
+
       class Suites
         attr_reader :fields
         def initialize(value)
-          @fields = value.to_s.split(/\s*,\s*/).map(&:to_sym)
+          @fields = if value.nil? || value.empty?
+                      DEFAULT_SUITES
+                    else
+                      value.to_s.split(/\s*,\s*/).map(&:to_sym)
+                    end
         end
 
         def include?(field)
           fields.include?(field)
+        end
+      end
+
+      class SuitesInclude < Suites
+        def initialize(value)
+          super
+          @fields = DEFAULT_SUITES + @fields
+        end
+      end
+
+      class SuitesExcept < Suites
+        def initialize(value)
+          super
+          @fields = DEFAULT_SUITES - @fields
         end
       end
 
       class SuitesAll
         def include?(value)
           true
-        end
-      end
-
-      class SuitesExcept < Suites
-        DEFAULT_SUITES = [:rack, :rack_method, :rack_status]
-
-        def initialize(value)
-          super
-          @fields = DEFAULT_SUITES - @fields
-        end
-
-        def include?(field)
-          fields.include?(field)
         end
       end
 

--- a/lib/librato/rack/configuration/suites.rb
+++ b/lib/librato/rack/configuration/suites.rb
@@ -1,0 +1,43 @@
+module Librato
+  class Rack
+    class Configuration
+
+      class Suites
+        attr_reader :fields
+        def initialize(value)
+          @fields = value.to_s.split(/\s*,\s*/).map(&:to_sym)
+        end
+
+        def include?(field)
+          fields.include?(field)
+        end
+      end
+
+      class SuitesAll
+        def include?(value)
+          true
+        end
+      end
+
+      class SuitesExcept < Suites
+        DEFAULT_SUITES = [:rack]
+
+        def initialize(value)
+          super
+          @fields = DEFAULT_SUITES - @fields
+        end
+
+        def include?(field)
+          fields.include?(field)
+        end
+      end
+
+      class SuitesNone
+        def include?(value)
+          false
+        end
+      end
+
+    end
+  end
+end

--- a/lib/librato/rack/configuration/suites.rb
+++ b/lib/librato/rack/configuration/suites.rb
@@ -34,12 +34,16 @@ module Librato
       end
 
       class SuitesAll
+        def fields; [:all]; end
+
         def include?(value)
           true
         end
       end
 
       class SuitesNone
+        def fields; []; end
+
         def include?(value)
           false
         end

--- a/lib/librato/rack/errors.rb
+++ b/lib/librato/rack/errors.rb
@@ -3,5 +3,7 @@ module Librato
 
     class InvalidLogLevel < RuntimeError; end
 
+    class InvalidSuiteConfiguration < RuntimeError; end
+
   end
 end

--- a/lib/librato/rack/tracker.rb
+++ b/lib/librato/rack/tracker.rb
@@ -101,6 +101,10 @@ module Librato
         logger.outlet = target
       end
 
+      def suite_enabled?(suite)
+        config.suites.include?(suite.to_sym)
+      end
+
       private
 
       # access to client instance

--- a/lib/librato/rack/tracker.rb
+++ b/lib/librato/rack/tracker.rb
@@ -102,7 +102,7 @@ module Librato
       end
 
       def suite_enabled?(suite)
-        config.suites.include?(suite.to_sym)
+        config.metric_suites.include?(suite.to_sym)
       end
 
       private

--- a/test/apps/basic.ru
+++ b/test/apps/basic.ru
@@ -1,6 +1,21 @@
 require 'bundler/setup'
 require 'librato-rack'
 
+# Simulate the environment variables Heroku passes along
+# with each request
+#
+class QueueWait
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    env['HTTP_X_QUEUE_START'] = (Time.now.to_f * 1000).to_i.to_s
+    @app.call(env)
+  end
+end
+
+use QueueWait
 use Librato::Rack
 
 def application(env)

--- a/test/apps/custom_suites.ru
+++ b/test/apps/custom_suites.ru
@@ -1,0 +1,18 @@
+require 'bundler/setup'
+require 'librato-rack'
+
+config = Librato::Rack::Configuration.new
+config.suites = '-rack_status,rack_method'
+
+use Librato::Rack, :config => config
+
+def application(env)
+  case env['PATH_INFO']
+  when '/exception'
+    raise 'exception raised!'
+  else
+    [200, {"Content-Type" => 'text/html'}, ["Hello!"]]
+  end
+end
+
+run method(:application)

--- a/test/apps/custom_suites.ru
+++ b/test/apps/custom_suites.ru
@@ -2,7 +2,7 @@ require 'bundler/setup'
 require 'librato-rack'
 
 config = Librato::Rack::Configuration.new
-config.suites = '-rack_status,rack_method'
+config.suites = '-rack_status,-rack_method'
 
 use Librato::Rack, :config => config
 

--- a/test/integration/no_suites_test.rb
+++ b/test/integration/no_suites_test.rb
@@ -27,6 +27,12 @@ class NoSuitesTest < Minitest::Test
     assert_nil counters["rack.request.total"], 'should not increment'
   end
 
+  def test_track_queue_time
+    get '/'
+    assert last_response.ok?
+    assert_equal nil, aggregate["rack.request.queue.time"]
+  end
+
   def test_increment_status
     get '/'
     assert last_response.ok?

--- a/test/integration/no_suites_test.rb
+++ b/test/integration/no_suites_test.rb
@@ -48,6 +48,16 @@ class NoSuitesTest < Minitest::Test
     assert_nil counters['rack.request.method.post']
   end
 
+  def test_increment_exception
+    begin
+      get '/exception'
+    rescue RuntimeError => e
+      raise unless e.message == 'exception raised!'
+    end
+
+    assert_nil counters["rack.request.exceptions"], 'should not increment'
+  end
+
   private
 
   def aggregate

--- a/test/integration/no_suites_test.rb
+++ b/test/integration/no_suites_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+require 'rack/test'
+
+# Tests to ensure tracking is disabled when a suite is removed. These tests
+# largely ensure that behavior verified positively other suites doesn't
+# happen when specific suites are disabled.
+#
+class NoSuitesTest < Minitest::Test
+  include Rack::Test::Methods
+  include EnvironmentHelpers
+
+  def app
+    ENV['LIBRATO_SUITES'] = 'none'
+    Rack::Builder.parse_file('test/apps/basic.ru').first
+  end
+
+  def teardown
+    # clear metrics before each run
+    aggregate.delete_all
+    counters.delete_all
+    clear_config_env_vars
+  end
+
+  def test_increment_total
+    get '/'
+    assert last_response.ok?
+    assert_nil counters["rack.request.total"], 'should not increment'
+  end
+
+  def test_increment_status
+    get '/'
+    assert last_response.ok?
+    assert_nil counters["rack.request.status.200"], 'should not increment'
+    assert_nil counters["rack.request.status.2xx"], 'should not increment'
+  end
+
+  def test_track_http_method_info
+    get '/'
+    assert_nil counters['rack.request.method.get']
+
+    post '/'
+    assert_nil counters['rack.request.method.post']
+  end
+
+  private
+
+  def aggregate
+    Librato.tracker.collector.aggregate
+  end
+
+  def counters
+    Librato.tracker.collector.counters
+  end
+
+end

--- a/test/integration/suites_test.rb
+++ b/test/integration/suites_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+require 'rack/test'
+
+# Tests to ensure config suites work
+#
+class SuitesTest < Minitest::Test
+  include Rack::Test::Methods
+
+  def app
+    Rack::Builder.parse_file('test/apps/custom_suites.ru').first
+  end
+
+  def teardown
+    # clear metrics before each run
+    aggregate.delete_all
+    counters.delete_all
+  end
+
+  def test_no_rack_status
+    get '/'
+    assert last_response.ok?
+
+    # rack.request metrics (rack suite) should get logged
+    assert_equal 1, counters["rack.request.total"]
+    assert_equal 1, aggregate["rack.request.time"][:count]
+
+    # rack.request.method metrics (rack_method suite) should not get logged
+    assert_equal nil, counters['rack.request.method.get']
+    assert_equal nil, aggregate['rack.request.method.get.time']
+
+    # rack.request.status metrics (rack_status suite) should not get logged
+    assert_equal nil, counters["rack.request.status.200"]
+    assert_equal nil, counters["rack.request.status.2xx"]
+    assert_equal nil, counters["rack.request.status.200.time"]
+    assert_equal nil, counters["rack.request.status.2xx.time"]
+  end
+
+  private
+
+  def aggregate
+    Librato.tracker.collector.aggregate
+  end
+
+  def counters
+    Librato.tracker.collector.counters
+  end
+
+end

--- a/test/support/environment_helpers.rb
+++ b/test/support/environment_helpers.rb
@@ -1,0 +1,24 @@
+# Helper methods for environment management that are shared
+# between test files.
+#
+module EnvironmentHelpers
+
+  def clear_config_env_vars
+    ENV.delete('LIBRATO_USER')
+    ENV.delete('LIBRATO_TOKEN')
+    ENV.delete('LIBRATO_PROXY')
+    ENV.delete('LIBRATO_SOURCE')
+    ENV.delete('LIBRATO_PREFIX')
+    ENV.delete('LIBRATO_SUITES')
+    ENV.delete('LIBRATO_SUITES_EXCEPT')
+    ENV.delete('LIBRATO_LOG_LEVEL')
+    ENV.delete('LIBRATO_EVENT_MODE')
+    # legacy - deprecated
+    ENV.delete('LIBRATO_METRICS_USER')
+    ENV.delete('LIBRATO_METRICS_TOKEN')
+    ENV.delete('LIBRATO_METRICS_SOURCE')
+    # system
+    ENV.delete('http_proxy')
+  end
+
+end

--- a/test/support/environment_helpers.rb
+++ b/test/support/environment_helpers.rb
@@ -10,7 +10,6 @@ module EnvironmentHelpers
     ENV.delete('LIBRATO_SOURCE')
     ENV.delete('LIBRATO_PREFIX')
     ENV.delete('LIBRATO_SUITES')
-    ENV.delete('LIBRATO_SUITES_EXCEPT')
     ENV.delete('LIBRATO_LOG_LEVEL')
     ENV.delete('LIBRATO_EVENT_MODE')
     # legacy - deprecated

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,3 +6,4 @@ require 'minitest/autorun'
 
 require 'librato/rack'
 
+require_relative 'support/environment_helpers'

--- a/test/unit/rack/configuration/suites_test.rb
+++ b/test/unit/rack/configuration/suites_test.rb
@@ -10,34 +10,38 @@ module Librato
 
       def test_suites_defaults
         config = Configuration.new
-        assert config.suites.include?(:rack), "should include 'rack' by default"
-        refute config.suites.include?(:foo), "should not include 'foo' by default"
-
-        ENV['LIBRATO_SUITES_EXCEPT'] = 'foo'
-        config = Configuration.new
-        assert config.suites.include?(:rack), "should include 'rack' if not excluded"
-
-        ENV['LIBRATO_SUITES_EXCEPT'] = 'rack'
-        config = Configuration.new
-        refute config.suites.include?(:rack), "should exclude 'rack'"
+        assert config.metric_suites.include?(:rack), "should include 'rack' by default"
+        refute config.metric_suites.include?(:foo), "should not include 'foo' by default"
       end
 
-      def test_suites_configured_by_inclusion
+      def test_suites_configured_by_explicit_list
         ENV['LIBRATO_SUITES'] = 'abc, jkl,prq , xyz'
         config = Configuration.new
         [:abc, :jkl, :prq, :xyz].each do |suite|
-          assert config.suites.include?(suite), "expected '#{suite}' to be active"
+          assert config.metric_suites.include?(suite), "expected '#{suite}' to be active"
         end
-        refute config.suites.include?(:something_else), 'should not include unspecified'
+        refute config.metric_suites.include?(:rack), "should not include 'rack' by default"
+        refute config.metric_suites.include?(:something_else), 'should not include unspecified'
+      end
+
+      def test_suites_configured_by_inclusion
+        ENV['LIBRATO_SUITES'] = '+abc, jkl,prq , xyz'
+        config = Configuration.new
+
+        [:rack_method, :jkl, :prq, :xyz].each do |suite|
+          assert config.metric_suites.include?(suite), "expected '#{suite.to_s}' to be active"
+        end
+        assert config.metric_suites.include?(:rack), "should include 'rack' by default"
       end
 
       def test_suites_configured_by_exclusion
-        ENV['LIBRATO_SUITES_EXCEPT'] = 'abc, jkl,prq , xyz'
+        ENV['LIBRATO_SUITES'] = '-rack_method, jkl,prq , xyz'
         config = Configuration.new
 
-        [:abc, :jkl, :prq, :xyz].each do |suite|
-          refute config.suites.include?(suite), "expected '#{suite}' to be inactive"
+        [:rack_method, :jkl, :prq, :xyz].each do |suite|
+          refute config.metric_suites.include?(suite), "expected '#{suite.to_s}' to be inactive"
         end
+        assert config.metric_suites.include?(:rack), "should include 'rack' by default"
       end
 
       def test_suites_all
@@ -45,7 +49,7 @@ module Librato
         config = Configuration.new
 
         [:foo, :bar, :baz].each do |suite|
-          assert config.suites.include?(suite), "expected '#{suite}' to be active"
+          assert config.metric_suites.include?(suite), "expected '#{suite}' to be active"
         end
       end
 
@@ -54,7 +58,7 @@ module Librato
         config = Configuration.new
 
         [:foo, :bar, :baz].each do |suite|
-          refute config.suites.include?(suite), "expected '#{suite}' to be active"
+          refute config.metric_suites.include?(suite), "expected '#{suite.to_s}' to be active"
         end
       end
 

--- a/test/unit/rack/configuration/suites_test.rb
+++ b/test/unit/rack/configuration/suites_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+module Librato
+  class Rack
+    class SuitesTest < Minitest::Test
+      include EnvironmentHelpers
+
+      def setup;    clear_config_env_vars; end
+      def teardown; clear_config_env_vars; end
+
+      def test_suites_defaults
+        config = Configuration.new
+        assert config.suites.include?(:rack), "should include 'rack' by default"
+        refute config.suites.include?(:foo), "should not include 'foo' by default"
+
+        ENV['LIBRATO_SUITES_EXCEPT'] = 'foo'
+        config = Configuration.new
+        assert config.suites.include?(:rack), "should include 'rack' if not excluded"
+
+        ENV['LIBRATO_SUITES_EXCEPT'] = 'rack'
+        config = Configuration.new
+        refute config.suites.include?(:rack), "should exclude 'rack'"
+      end
+
+      def test_suites_configured_by_inclusion
+        ENV['LIBRATO_SUITES'] = 'abc, jkl,prq , xyz'
+        config = Configuration.new
+        [:abc, :jkl, :prq, :xyz].each do |suite|
+          assert config.suites.include?(suite), "expected '#{suite}' to be active"
+        end
+        refute config.suites.include?(:something_else), 'should not include unspecified'
+      end
+
+      def test_suites_configured_by_exclusion
+        ENV['LIBRATO_SUITES_EXCEPT'] = 'abc, jkl,prq , xyz'
+        config = Configuration.new
+
+        [:abc, :jkl, :prq, :xyz].each do |suite|
+          refute config.suites.include?(suite), "expected '#{suite}' to be inactive"
+        end
+      end
+
+      def test_suites_all
+        ENV['LIBRATO_SUITES'] = 'all'
+        config = Configuration.new
+
+        [:foo, :bar, :baz].each do |suite|
+          assert config.suites.include?(suite), "expected '#{suite}' to be active"
+        end
+      end
+
+      def test_suites_none
+        ENV['LIBRATO_SUITES'] = 'NONE'
+        config = Configuration.new
+
+        [:foo, :bar, :baz].each do |suite|
+          refute config.suites.include?(suite), "expected '#{suite}' to be active"
+        end
+      end
+
+    end
+  end
+end

--- a/test/unit/rack/configuration_test.rb
+++ b/test/unit/rack/configuration_test.rb
@@ -44,8 +44,6 @@ module Librato
           assert config.suites.include?(suite), "expected '#{suite}' to be active"
         end
         refute config.suites.include?(:something_else)
-      ensure
-        ENV.delete('LIBRATO_SUITES')
       end
 
       def test_suites_configured_by_exclusion
@@ -56,8 +54,6 @@ module Librato
           refute config.suites.include?(suite), "expected '#{suite}' to be inactive"
         end
         assert config.suites.include?(:something_else)
-      ensure
-        ENV.delete('LIBRATO_SUITES_EXCEPT')
       end
 
       def test_suites_all
@@ -67,8 +63,6 @@ module Librato
         [:foo, :bar, :baz].each do |suite|
           assert config.suites.include?(suite), "expected '#{suite}' to be active"
         end
-      ensure
-        ENV.delete('LIBRATO_SUITES')
       end
 
       def test_suites_none
@@ -78,8 +72,6 @@ module Librato
         [:foo, :bar, :baz].each do |suite|
           refute config.suites.include?(suite), "expected '#{suite}' to be active"
         end
-      ensure
-        ENV.delete('LIBRATO_SUITES')
       end
 
       def test_legacy_env_variable_config
@@ -146,9 +138,11 @@ module Librato
         ENV.delete('LIBRATO_PROXY')
         ENV.delete('LIBRATO_SOURCE')
         ENV.delete('LIBRATO_PREFIX')
+        ENV.delete('LIBRATO_SUITES')
+        ENV.delete('LIBRATO_SUITES_EXCEPT')
         ENV.delete('LIBRATO_LOG_LEVEL')
         ENV.delete('LIBRATO_EVENT_MODE')
-        # legacy
+        # legacy - deprecated
         ENV.delete('LIBRATO_METRICS_USER')
         ENV.delete('LIBRATO_METRICS_TOKEN')
         ENV.delete('LIBRATO_METRICS_SOURCE')

--- a/test/unit/rack/configuration_test.rb
+++ b/test/unit/rack/configuration_test.rb
@@ -3,14 +3,10 @@ require 'test_helper'
 module Librato
   class Rack
     class ConfigurationTest < Minitest::Test
+      include EnvironmentHelpers
 
-      def setup
-        clear_env_vars
-      end
-
-      def teardown
-        clear_env_vars
-      end
+      def setup;    clear_config_env_vars; end
+      def teardown; clear_config_env_vars; end
 
       def test_defaults
         config = Configuration.new
@@ -29,56 +25,6 @@ module Librato
         assert_equal 'source', config.source
         assert_equal 'http://localhost:8080', config.proxy
         #assert Librato::Rails.explicit_source, 'source is explicit'
-      end
-
-      def test_suites_defaults
-        config = Configuration.new
-        assert config.suites.include?(:rack), "should include 'rack' by default"
-        refute config.suites.include?(:foo), "should not include 'foo' by default"
-
-        ENV['LIBRATO_SUITES_EXCEPT'] = 'foo'
-        config = Configuration.new
-        assert config.suites.include?(:rack), "should include 'rack' if not excluded"
-
-        ENV['LIBRATO_SUITES_EXCEPT'] = 'rack'
-        config = Configuration.new
-        refute config.suites.include?(:rack), "should exclude 'rack'"
-      end
-
-      def test_suites_configured_by_inclusion
-        ENV['LIBRATO_SUITES'] = 'abc, jkl,prq , xyz'
-        config = Configuration.new
-        [:abc, :jkl, :prq, :xyz].each do |suite|
-          assert config.suites.include?(suite), "expected '#{suite}' to be active"
-        end
-        refute config.suites.include?(:something_else), 'should not include unspecified'
-      end
-
-      def test_suites_configured_by_exclusion
-        ENV['LIBRATO_SUITES_EXCEPT'] = 'abc, jkl,prq , xyz'
-        config = Configuration.new
-
-        [:abc, :jkl, :prq, :xyz].each do |suite|
-          refute config.suites.include?(suite), "expected '#{suite}' to be inactive"
-        end
-      end
-
-      def test_suites_all
-        ENV['LIBRATO_SUITES'] = 'all'
-        config = Configuration.new
-
-        [:foo, :bar, :baz].each do |suite|
-          assert config.suites.include?(suite), "expected '#{suite}' to be active"
-        end
-      end
-
-      def test_suites_none
-        ENV['LIBRATO_SUITES'] = 'NONE'
-        config = Configuration.new
-
-        [:foo, :bar, :baz].each do |suite|
-          refute config.suites.include?(suite), "expected '#{suite}' to be active"
-        end
       end
 
       def test_legacy_env_variable_config
@@ -138,24 +84,6 @@ module Librato
       end
 
       private
-
-      def clear_env_vars
-        ENV.delete('LIBRATO_USER')
-        ENV.delete('LIBRATO_TOKEN')
-        ENV.delete('LIBRATO_PROXY')
-        ENV.delete('LIBRATO_SOURCE')
-        ENV.delete('LIBRATO_PREFIX')
-        ENV.delete('LIBRATO_SUITES')
-        ENV.delete('LIBRATO_SUITES_EXCEPT')
-        ENV.delete('LIBRATO_LOG_LEVEL')
-        ENV.delete('LIBRATO_EVENT_MODE')
-        # legacy - deprecated
-        ENV.delete('LIBRATO_METRICS_USER')
-        ENV.delete('LIBRATO_METRICS_TOKEN')
-        ENV.delete('LIBRATO_METRICS_SOURCE')
-        # system
-        ENV.delete('http_proxy')
-      end
 
       def listener_object
         listener = Object.new

--- a/test/unit/rack/configuration_test.rb
+++ b/test/unit/rack/configuration_test.rb
@@ -60,6 +60,28 @@ module Librato
         ENV.delete('LIBRATO_SUITES_EXCEPT')
       end
 
+      def test_suites_all
+        ENV['LIBRATO_SUITES'] = 'all'
+        config = Configuration.new
+
+        [:foo, :bar, :baz].each do |suite|
+          assert config.suites.include?(suite), "expected '#{suite}' to be active"
+        end
+      ensure
+        ENV.delete('LIBRATO_SUITES')
+      end
+
+      def test_suites_none
+        ENV['LIBRATO_SUITES'] = 'NONE'
+        config = Configuration.new
+
+        [:foo, :bar, :baz].each do |suite|
+          refute config.suites.include?(suite), "expected '#{suite}' to be active"
+        end
+      ensure
+        ENV.delete('LIBRATO_SUITES')
+      end
+
       def test_legacy_env_variable_config
         ENV['LIBRATO_METRICS_USER'] = 'foo@bar.com'
         ENV['LIBRATO_METRICS_TOKEN'] = 'api_key'

--- a/test/unit/rack/configuration_test.rb
+++ b/test/unit/rack/configuration_test.rb
@@ -12,6 +12,7 @@ module Librato
         config = Configuration.new
         assert_equal 60, config.flush_interval
         assert_equal Librato::Metrics.api_endpoint, config.api_endpoint
+        assert_equal '', config.suites
       end
 
       def test_environment_variable_config
@@ -19,11 +20,13 @@ module Librato
         ENV['LIBRATO_TOKEN'] = 'api_key'
         ENV['LIBRATO_SOURCE'] = 'source'
         ENV['LIBRATO_PROXY'] = 'http://localhost:8080'
+        ENV['LIBRATO_SUITES'] = 'foo,bar'
         config = Configuration.new
         assert_equal 'foo@bar.com', config.user
         assert_equal 'api_key', config.token
         assert_equal 'source', config.source
         assert_equal 'http://localhost:8080', config.proxy
+        assert_equal 'foo,bar', config.suites
         #assert Librato::Rails.explicit_source, 'source is explicit'
       end
 

--- a/test/unit/rack/configuration_test.rb
+++ b/test/unit/rack/configuration_test.rb
@@ -31,10 +31,18 @@ module Librato
         #assert Librato::Rails.explicit_source, 'source is explicit'
       end
 
-      def test_unconfigured_suites_are_on_by_default
+      def test_suites_defaults
         config = Configuration.new
-        assert config.suites.include?(:abc)
-        assert config.suites.include?(:xyz)
+        assert config.suites.include?(:rack), "should include 'rack' by default"
+        refute config.suites.include?(:foo), "should not include 'foo' by default"
+
+        ENV['LIBRATO_SUITES_EXCEPT'] = 'foo'
+        config = Configuration.new
+        assert config.suites.include?(:rack), "should include 'rack' if not excluded"
+
+        ENV['LIBRATO_SUITES_EXCEPT'] = 'rack'
+        config = Configuration.new
+        refute config.suites.include?(:rack), "should exclude 'rack'"
       end
 
       def test_suites_configured_by_inclusion
@@ -43,7 +51,7 @@ module Librato
         [:abc, :jkl, :prq, :xyz].each do |suite|
           assert config.suites.include?(suite), "expected '#{suite}' to be active"
         end
-        refute config.suites.include?(:something_else)
+        refute config.suites.include?(:something_else), 'should not include unspecified'
       end
 
       def test_suites_configured_by_exclusion
@@ -53,7 +61,6 @@ module Librato
         [:abc, :jkl, :prq, :xyz].each do |suite|
           refute config.suites.include?(suite), "expected '#{suite}' to be inactive"
         end
-        assert config.suites.include?(:something_else)
       end
 
       def test_suites_all

--- a/test/unit/rack/configuration_test.rb
+++ b/test/unit/rack/configuration_test.rb
@@ -31,6 +31,35 @@ module Librato
         #assert Librato::Rails.explicit_source, 'source is explicit'
       end
 
+      def test_unconfigured_suites_are_on_by_default
+        config = Configuration.new
+        assert config.suites.include?(:abc)
+        assert config.suites.include?(:xyz)
+      end
+
+      def test_suites_configured_by_inclusion
+        ENV['LIBRATO_SUITES'] = 'abc, jkl,prq , xyz'
+        config = Configuration.new
+        [:abc, :jkl, :prq, :xyz].each do |suite|
+          assert config.suites.include?(suite), "expected '#{suite}' to be active"
+        end
+        refute config.suites.include?(:something_else)
+      ensure
+        ENV.delete('LIBRATO_SUITES')
+      end
+
+      def test_suites_configured_by_exclusion
+        ENV['LIBRATO_SUITES_EXCEPT'] = 'abc, jkl,prq , xyz'
+        config = Configuration.new
+
+        [:abc, :jkl, :prq, :xyz].each do |suite|
+          refute config.suites.include?(suite), "expected '#{suite}' to be inactive"
+        end
+        assert config.suites.include?(:something_else)
+      ensure
+        ENV.delete('LIBRATO_SUITES_EXCEPT')
+      end
+
       def test_legacy_env_variable_config
         ENV['LIBRATO_METRICS_USER'] = 'foo@bar.com'
         ENV['LIBRATO_METRICS_TOKEN'] = 'api_key'

--- a/test/unit/rack/tracker_test.rb
+++ b/test/unit/rack/tracker_test.rb
@@ -46,6 +46,17 @@ module Librato
         ENV.delete('LIBRATO_AUTORUN')
       end
 
+      def test_suite_configured
+        ENV['LIBRATO_SUITES'] = 'abc,prq'
+
+        tracker = Tracker.new(Configuration.new)
+        assert tracker.suite_enabled?(:abc)
+        assert tracker.suite_enabled?(:prq)
+        refute tracker.suite_enabled?(:xyz)
+      ensure
+        ENV.delete('LIBRATO_SUITES')
+      end
+
       private
 
       def buffer_lines


### PR DESCRIPTION
Extends #38 to provide support for a core set of configurable suites with the ability to enable/disable them selectively. This lays initial groundwork w/ configuration detection, tracker/suite management and breaks our highest volume metrics into three suites.

Related discussion: https://github.com/librato/librato-rails/issues/71