### PR TITLE
Disable 'rack.processes' metric if config.disable_rack_metrics is true

### DIFF
--- a/lib/librato/rack/tracker.rb
+++ b/lib/librato/rack/tracker.rb
@@ -126,7 +126,7 @@ module Librato
         [collector.counters, collector.aggregate].each do |cache|
           cache.flush_to(queue, preserve: preserve)
         end
-        queue.add 'rack.processes' => 1
+        queue.add 'rack.processes' => 1 unless config.disable_rack_metrics
         trace_queued(queue.queued) #if should_log?(:trace)
         queue
       end


### PR DESCRIPTION
If someone disables rack metrics in the config, 'rack.processes' should also not be sent.