### PR TITLE
Feature/percentiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ The block form auto-submits the time it took for its contents to execute as the 
       @twitter = Twitter.lookup(user)
     end
 
+###### percentiles (beta)
+
+By defaults timings will send the average, sum, max and min for every minute. If you want to send percentiles as well you can specify them inline while instrumenting:
+
+    # track a single percentile
+    Librato.timing 'api.request.time', time, percentile: 95
+
+    # track multiple percentiles
+    Librato.timing 'api.request.time', time, percentile: [95, 99]
+
+You can also use percentiles with the block form of timings:
+
+    Librato.timing 'my.important.event', percentile: 95 do
+      # do work
+    end
+
 #### group
 
 There is also a grouping helper, to make managing nested metrics easier. So this:

--- a/lib/librato/collector.rb
+++ b/lib/librato/collector.rb
@@ -10,7 +10,7 @@ module Librato
 
     # access to internal aggregator object
     def aggregate
-      @aggregator_cache ||= Aggregator.new(:prefix => @prefix)
+      @aggregator_cache ||= Aggregator.new(prefix: @prefix)
     end
 
     # access to internal counters object

--- a/lib/librato/collector.rb
+++ b/lib/librato/collector.rb
@@ -43,6 +43,7 @@ module Librato
   end
 end
 
-require 'librato/collector/aggregator'
-require 'librato/collector/counter_cache'
-require 'librato/collector/group'
+require_relative 'collector/aggregator'
+require_relative 'collector/counter_cache'
+require_relative 'collector/exceptions'
+require_relative 'collector/group'

--- a/lib/librato/collector/aggregator.rb
+++ b/lib/librato/collector/aggregator.rb
@@ -21,6 +21,8 @@ module Librato
         fetch(key)
       end
 
+      # retrieve current value of a metric/source/percentage. this exists
+      # primarily for debugging/testing and isn't called routinely.
       def fetch(key, options={})
         return nil if @cache.empty?
         return fetch_percentile(key, options) if options[:percentile]
@@ -36,6 +38,7 @@ module Librato
         nil
       end
 
+      # clear all stored values
       def delete_all
         @lock.synchronize {
           @cache.clear

--- a/lib/librato/collector/aggregator.rb
+++ b/lib/librato/collector/aggregator.rb
@@ -40,10 +40,7 @@ module Librato
 
       # clear all stored values
       def delete_all
-        @lock.synchronize {
-          @cache.clear
-          @percentiles = {}
-        }
+        @lock.synchronize { clear_storage }
       end
 
       # transfer all measurements to queue and reset internal status
@@ -53,7 +50,7 @@ module Librato
           return if @cache.empty?
           queued = @cache.queued
           flush_percentiles(queue, opts) unless @percentiles.empty?
-          @cache.clear unless opts[:preserve]
+          clear_storage unless opts[:preserve]
         end
         queue.merge!(queued) if queued
       end
@@ -114,6 +111,11 @@ module Librato
 
       private
 
+      def clear_storage
+        @cache.clear
+        @percentiles = {}
+      end
+
       def fetch_percentile(key, options)
         store = fetch_percentile_store(key, options[:source])
         return nil unless store
@@ -141,7 +143,6 @@ module Librato
             queue.add "#{metric}.p#{perc_name}" => payload
           end
         end
-        @percentiles = {} unless opts[:preserve]
       end
 
       def track_percentile(store, perc)

--- a/lib/librato/collector/aggregator.rb
+++ b/lib/librato/collector/aggregator.rb
@@ -112,7 +112,7 @@ module Librato
       end
 
       def fetch_percentile(key, options)
-        store = fetch_percentile_store(key, nil)
+        store = fetch_percentile_store(key, options[:source])
         return nil unless store
         store.percentile(options[:percentile])
       end

--- a/lib/librato/collector/aggregator.rb
+++ b/lib/librato/collector/aggregator.rb
@@ -113,8 +113,9 @@ module Librato
 
       def clear_storage
         @cache.clear
-        unless @percentiles.empty?
-          @percentiles = {}
+        @percentiles.each do |key, val|
+          val[:reservoir].clear
+          val[:percs].clear
         end
       end
 

--- a/lib/librato/collector/aggregator.rb
+++ b/lib/librato/collector/aggregator.rb
@@ -127,7 +127,5 @@ module Librato
 
     end
 
-    # custom exceptions
-    class InvalidPercentile < StandardError; end
   end
 end

--- a/lib/librato/collector/aggregator.rb
+++ b/lib/librato/collector/aggregator.rb
@@ -94,6 +94,7 @@ module Librato
           end
 
           percentiles.each do |perc|
+            check_percentile(perc)
             store = fetch_percentile_store(event, source)
             store << value
           end
@@ -103,6 +104,12 @@ module Librato
       alias :timing :measure
 
       private
+
+      def check_percentile(perc)
+        if perc < 0.0 || perc > 100.0
+          raise InvalidPercentile, "Percentiles must be between 0.0 and 100.0"
+        end
+      end
 
       def fetch_percentile(key, options)
         store = fetch_percentile_store(key, nil)
@@ -116,5 +123,8 @@ module Librato
       end
 
     end
+
+    # custom exceptions
+    class InvalidPercentile < StandardError; end
   end
 end

--- a/lib/librato/collector/aggregator.rb
+++ b/lib/librato/collector/aggregator.rb
@@ -113,7 +113,9 @@ module Librato
 
       def clear_storage
         @cache.clear
-        @percentiles = {}
+        unless @percentiles.empty?
+          @percentiles = {}
+        end
       end
 
       def fetch_percentile(key, options)

--- a/lib/librato/collector/aggregator.rb
+++ b/lib/librato/collector/aggregator.rb
@@ -10,7 +10,7 @@ module Librato
       def_delegators :@cache, :empty?, :prefix, :prefix=
 
       def initialize(options={})
-        @cache = Librato::Metrics::Aggregator.new(:prefix => options[:prefix])
+        @cache = Librato::Metrics::Aggregator.new(prefix: options[:prefix])
         @percentiles = {}
         @lock = Mutex.new
       end
@@ -88,7 +88,7 @@ module Librato
 
         @lock.synchronize do
           if source
-            @cache.add event => {:source => source, :value => value}
+            @cache.add event => {source: source, value: value}
           else
             @cache.add event => value
           end

--- a/lib/librato/collector/aggregator.rb
+++ b/lib/librato/collector/aggregator.rb
@@ -35,7 +35,10 @@ module Librato
       end
 
       def delete_all
-        @lock.synchronize { @cache.clear }
+        @lock.synchronize {
+          @cache.clear
+          @percentiles = {}
+        }
       end
 
       # transfer all measurements to queue and reset internal status

--- a/lib/librato/collector/counter_cache.rb
+++ b/lib/librato/collector/counter_cache.rb
@@ -55,7 +55,7 @@ module Librato
         counts.each do |metric, value|
           metric, source = metric.split(SEPARATOR)
           if source
-            queue.add metric => {:value => value, :source => source}
+            queue.add metric => {value: value, source: source}
           else
             queue.add metric => value
           end

--- a/lib/librato/collector/counter_cache.rb
+++ b/lib/librato/collector/counter_cache.rb
@@ -76,7 +76,7 @@ module Librato
       def increment(counter, options={})
         if options.is_a?(Fixnum)
           # suppport legacy style
-          options = {:by => options}
+          options = {by: options}
         end
         by = options[:by] || 1
         if options[:source]

--- a/lib/librato/collector/exceptions.rb
+++ b/lib/librato/collector/exceptions.rb
@@ -1,0 +1,8 @@
+module Librato
+  class Collector
+
+    # custom exceptions
+    class InvalidPercentile < StandardError; end
+
+  end
+end

--- a/lib/librato/rack.rb
+++ b/lib/librato/rack.rb
@@ -107,10 +107,10 @@ module Librato
         case queue_start.length
         when 16 # microseconds
           wait = ((Time.now.to_f * 1000000).to_i - queue_start.to_i) / 1000.0
-          tracker.timing 'rack.request.queue.time', wait
+          tracker.timing 'rack.request.queue.time', wait, percentile: 95
         when 13 # milliseconds
           wait = (Time.now.to_f * 1000).to_i - queue_start.to_i
-          tracker.timing 'rack.request.queue.time', wait
+          tracker.timing 'rack.request.queue.time', wait, percentile: 95
         end
       end
     end
@@ -119,7 +119,7 @@ module Librato
       return if config.disable_rack_metrics
       tracker.group 'rack.request' do |group|
         group.increment 'total'
-        group.timing    'time', duration
+        group.timing    'time', duration, percentile: 95
         group.increment 'slow' if duration > 200.0
 
         group.group 'status' do |s|

--- a/librato-rack.gemspec
+++ b/librato-rack.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "librato-metrics", "~> 1.1"
+  s.add_dependency "hetchy", "~> 1.0"
   s.add_development_dependency "minitest"
 
   s.cert_chain = ["certs/librato-public.pem"]

--- a/test/unit/collector/aggregator_test.rb
+++ b/test/unit/collector/aggregator_test.rb
@@ -62,6 +62,15 @@ module Librato
         }
       end
 
+      def test_percentiles_with_source
+        Array(1..10).each do |val|
+          @agg.timing 'a.sample.thing', val, percentile: 50, source: 'foo'
+        end
+        assert_equal 5.5,
+          @agg.fetch('a.sample.thing', source: 'foo', percentile: 50),
+          'can calculate percentile with source'
+      end
+
       # Todo: mult percentiles, block form, with source, invalid percentile
 
       def test_return_values

--- a/test/unit/collector/aggregator_test.rb
+++ b/test/unit/collector/aggregator_test.rb
@@ -27,6 +27,16 @@ module Librato
         assert_in_delta @agg['another.task'][:sum], 100, 50
       end
 
+      def test_percentiles
+        [0.1, 0.2, 0.3].each do |val|
+          @agg.timing 'a.sample.thing', val, percentile: 50
+        end
+
+        assert_equal 0.2, @agg.fetch('a.sample.thing', percentile: 50)
+
+        # Todo: mult percentiles, block form, with source, invalid percentile
+      end
+
       def test_return_values
         simple = @agg.timing 'simple', 20
         assert_equal nil, simple

--- a/test/unit/collector/aggregator_test.rb
+++ b/test/unit/collector/aggregator_test.rb
@@ -135,6 +135,10 @@ module Librato
         assert_nil a_timing[:source],             'no source set'
         assert_equal 'f', b_timing_50[:source],   'proper source set'
         assert_equal 'f', b_timing_999[:source],  'proper source set'
+
+        # flushing clears percentages to track
+        storage = @agg.instance_variable_get('@percentiles')
+        assert_equal 0, storage['a.timing'][:percs].length, 'clears percentiles'
       end
 
     end


### PR DESCRIPTION
Adds ability to report one or more percentiles for any `Librato.timing`, for example:

```ruby
Librato.timing 'user.authentication.time', time, percentile: [50,95]
```

Percentiles are currently sent as parallel metrics. In the case above the following metrics would be sent:

```
user.authentication.time
user.authentication.time.p50
user.authentication.time.p95
```

95th percentiles are also now enabled by default for `rack.request.time` and `rack.request.queue.time`.