### PR TITLE
Ensure forwardable is required

### DIFF
--- a/lib/librato/collector.rb
+++ b/lib/librato/collector.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module Librato
   # collects and stores measurement values over time so they can be
   # reported periodically to the Metrics service


### PR DESCRIPTION
In some environments this may not already be available, make sure it is always formally required.