### PR TITLE
Add proxy configuration support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Master
+* Add support for proxy configuration
+
 ### Version 0.5.0
 * Add support for percentiles when timing
 * Report p95 for rack.request.time and rack.request.queue.time

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ By default you can use `LIBRATO_USER` and `LIBRATO_TOKEN` to pass your account d
 * `LIBRATO_PREFIX` - a prefix which will be prepended to all metric names
 * `LIBRATO_AUTORUN` - set to `'0'` to prevent the reporter from starting, useful if you don't want `librato-rack` to start under certain circumstances
 * `LIBRATO_LOG_LEVEL` - see logging section for more
+* `LIBRATO_PROXY` - HTTP proxy to use when connecting to the Librato API (can also use the `https_proxy` or `http_proxy` environment variable commonly supported by Linux command line utilities)
 * `LIBRATO_EVENT_MODE` - use with evented apps, see "Use with EventMachine" below
 
 ##### Use a configuration object

--- a/lib/librato/rack/configuration.rb
+++ b/lib/librato/rack/configuration.rb
@@ -14,7 +14,7 @@ module Librato
 
       attr_accessor :user, :token, :autorun, :api_endpoint, :tracker,
                     :source_pids, :log_level, :log_prefix, :log_target,
-                    :disable_rack_metrics, :flush_interval
+                    :disable_rack_metrics, :flush_interval, :proxy
       attr_reader :prefix, :source, :deprecations
 
       def initialize
@@ -59,6 +59,7 @@ module Librato
         self.prefix = ENV['LIBRATO_PREFIX'] || ENV['LIBRATO_METRICS_PREFIX']
         self.source = ENV['LIBRATO_SOURCE'] || ENV['LIBRATO_METRICS_SOURCE']
         self.log_level = ENV['LIBRATO_LOG_LEVEL'] || :info
+        self.proxy = ENV['LIBRATO_PROXY'] || ENV['https_proxy'] || ENV['http_proxy']
         self.event_mode = ENV['LIBRATO_EVENT_MODE']
         check_deprecations
       end

--- a/lib/librato/rack/tracker.rb
+++ b/lib/librato/rack/tracker.rb
@@ -149,6 +149,7 @@ module Librato
         client = Librato::Metrics::Client.new
         client.authenticate config.user, config.token
         client.api_endpoint = config.api_endpoint
+        client.proxy = config.proxy
         client.custom_user_agent = user_agent
         if custom_adapter
           client.faraday_adapter = custom_adapter

--- a/librato-rack.gemspec
+++ b/librato-rack.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE", "Rakefile", "README.md", "CHANGELOG.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "librato-metrics", "~> 1.1"
+  s.add_dependency "librato-metrics", "~> 1.6"
   s.add_dependency "hetchy", "~> 1.0"
   s.add_development_dependency "minitest"
 

--- a/test/unit/rack/configuration_test.rb
+++ b/test/unit/rack/configuration_test.rb
@@ -22,10 +22,12 @@ module Librato
         ENV['LIBRATO_USER'] = 'foo@bar.com'
         ENV['LIBRATO_TOKEN'] = 'api_key'
         ENV['LIBRATO_SOURCE'] = 'source'
+        ENV['LIBRATO_PROXY'] = 'http://localhost:8080'
         config = Configuration.new
         assert_equal 'foo@bar.com', config.user
         assert_equal 'api_key', config.token
         assert_equal 'source', config.source
+        assert_equal 'http://localhost:8080', config.proxy
         #assert Librato::Rails.explicit_source, 'source is explicit'
       end
 
@@ -38,6 +40,12 @@ module Librato
         assert_equal 'api_key', config.token
         assert_equal 'source', config.source
         # assert Librato::Rails.explicit_source, 'source is explicit'
+      end
+
+      def test_http_proxy_env_variable_config
+        ENV['http_proxy'] = 'http://localhost:8888'
+        config = Configuration.new
+        assert_equal 'http://localhost:8888', config.proxy
       end
 
       def test_explicit_source
@@ -84,6 +92,7 @@ module Librato
       def clear_env_vars
         ENV.delete('LIBRATO_USER')
         ENV.delete('LIBRATO_TOKEN')
+        ENV.delete('LIBRATO_PROXY')
         ENV.delete('LIBRATO_SOURCE')
         ENV.delete('LIBRATO_PREFIX')
         ENV.delete('LIBRATO_LOG_LEVEL')
@@ -92,6 +101,8 @@ module Librato
         ENV.delete('LIBRATO_METRICS_USER')
         ENV.delete('LIBRATO_METRICS_TOKEN')
         ENV.delete('LIBRATO_METRICS_SOURCE')
+        # system
+        ENV.delete('http_proxy')
       end
 
       def listener_object


### PR DESCRIPTION
Can configure an HTTP proxy directly on the `Configuration` object or by specifying either `http_proxy` or `LIBRATO_PROXY` environment variables.

Fixes #45 