### PR TITLE
Rearrange config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ By default you can use `LIBRATO_USER` and `LIBRATO_TOKEN` to pass your account d
 * `LIBRATO_SOURCE` - the default source to use for submitted metrics. If this is not set, hostname of the executing machine will be the default source
 * `LIBRATO_SUITES` - manage which metrics librato-rack will report. See more in [metrics suites](#metric-suites).
 * `LIBRATO_PREFIX` - a prefix which will be prepended to all metric names
-* `LIBRATO_AUTORUN` - set to `'0'` to prevent the reporter from starting, useful if you don't want `librato-rack` to start under certain circumstances
 * `LIBRATO_LOG_LEVEL` - see logging section for more
 * `LIBRATO_PROXY` - HTTP proxy to use when connecting to the Librato API (can also use the `https_proxy` or `http_proxy` environment variable commonly supported by Linux command line utilities)
+* `LIBRATO_AUTORUN` - set to `'0'` to prevent the reporter from starting, useful if you don't want `librato-rack` to start under certain circumstances
 * `LIBRATO_EVENT_MODE` - use with evented apps, see "Use with EventMachine" below
 
 ##### Use a configuration object


### PR DESCRIPTION
Move LIBRATO_AUTORUN down since it is rarely used.