### PR TITLE
Fix missing p95 for request.time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version X.X.X
+* Fix missing p95 for rack.request.time
+
 ### Version 1.0.0
 * Add support for configurable metric suites
 * Drop support for long-deprecated config via LIBRATO_METRICS_* env vars

--- a/lib/librato/rack.rb
+++ b/lib/librato/rack.rb
@@ -39,7 +39,7 @@ module Librato
   class Rack
     RECORD_RACK_BODY = <<-'EOS'
       group.increment 'total'
-      group.timing    'time', duration
+      group.timing    'time', duration, percentile: 95
       group.increment 'slow' if duration > 200.0
     EOS
 

--- a/test/integration/request_test.rb
+++ b/test/integration/request_test.rb
@@ -37,6 +37,9 @@ class RequestTest < Minitest::Test
     assert_equal 1, aggregate["rack.request.time"][:count],
       'should track total request time'
 
+    # should calculte p95 value
+    refute_equal aggregate.fetch("rack.request.time", percentile: 95), 0.0
+
     # status specific
     assert_equal 1, aggregate["rack.request.status.200.time"][:count]
     assert_equal 1, aggregate["rack.request.status.2xx.time"][:count]


### PR DESCRIPTION
I noticed today that `rack.request.time.p95` isn't reporting properly, it looks like we lost the percentile in the refactor for v1.0. 

It used to [live here](https://github.com/librato/librato-rack/blob/v0.6.0/lib/librato/rack.rb#L122) in v0.6.

I'm pretty sure this is all that is needed to fix, but we should probably stage this to verify & think about the best way to add a regression test since this is important.

/cc @bdehamer 