### PR TITLE
Ensure Ruby 2.4 does not throw deprecation warnings

### DIFF
--- a/lib/librato/collector/counter_cache.rb
+++ b/lib/librato/collector/counter_cache.rb
@@ -74,7 +74,8 @@ module Librato
       #   increment :foo, :source => user.id
       #
       def increment(counter, options={})
-        if options.is_a?(Fixnum)
+        integer_class = 1.class
+        if options.is_a?(integer_class)
           # suppport legacy style
           options = {by: options}
         end


### PR DESCRIPTION
Let's avoid this

```sh
/vendor/bundle/ruby/2.4.0/gems/librato-rack-0.4.5/lib/librato/collector/counter_cache.rb:77: warning: constant ::Fixnum is deprecated
```