### PR TITLE
Use assert_nil if expecting nil

### DIFF
--- a/test/integration/no_stats_test.rb
+++ b/test/integration/no_stats_test.rb
@@ -20,16 +20,16 @@ class NoStatsTest < Minitest::Test
     get '/'
     assert last_response.ok?
 
-    assert_equal nil, counters["rack.request.total"]
-    assert_equal nil, counters["rack.request.status.200"]
-    assert_equal nil, counters["rack.request.status.2xx"]
+    assert_nil counters["rack.request.total"]
+    assert_nil counters["rack.request.status.200"]
+    assert_nil counters["rack.request.status.2xx"]
   end
 
   def test_no_standard_measures
     get '/'
     assert last_response.ok?
 
-    assert_equal nil, aggregate["rack.request.time"]
+    assert_nil aggregate["rack.request.time"]
   end
 
   def test_dont_track_exceptions
@@ -38,7 +38,7 @@ class NoStatsTest < Minitest::Test
     rescue RuntimeError => e
       raise unless e.message == 'exception raised!'
     end
-    assert_equal nil, counters["rack.request.exceptions"]
+    assert_nil counters["rack.request.exceptions"]
   end
 
   private

--- a/test/integration/no_suites_test.rb
+++ b/test/integration/no_suites_test.rb
@@ -30,7 +30,7 @@ class NoSuitesTest < Minitest::Test
   def test_track_queue_time
     get '/'
     assert last_response.ok?
-    assert_equal nil, aggregate["rack.request.queue.time"]
+    assert_nil aggregate["rack.request.queue.time"]
   end
 
   def test_increment_status

--- a/test/integration/suites_test.rb
+++ b/test/integration/suites_test.rb
@@ -25,14 +25,14 @@ class SuitesTest < Minitest::Test
     assert_equal 1, aggregate["rack.request.time"][:count]
 
     # rack.request.method metrics (rack_method suite) should not get logged
-    assert_equal nil, counters['rack.request.method.get']
-    assert_equal nil, aggregate['rack.request.method.get.time']
+    assert_nil counters['rack.request.method.get']
+    assert_nil aggregate['rack.request.method.get.time']
 
     # rack.request.status metrics (rack_status suite) should not get logged
-    assert_equal nil, counters["rack.request.status.200"]
-    assert_equal nil, counters["rack.request.status.2xx"]
-    assert_equal nil, counters["rack.request.status.200.time"]
-    assert_equal nil, counters["rack.request.status.2xx.time"]
+    assert_nil counters["rack.request.status.200"]
+    assert_nil counters["rack.request.status.2xx"]
+    assert_nil counters["rack.request.status.200.time"]
+    assert_nil counters["rack.request.status.2xx.time"]
   end
 
   private

--- a/test/remote/tracker_test.rb
+++ b/test/remote/tracker_test.rb
@@ -58,7 +58,7 @@ class TrackerRemoteTest < Minitest::Test
 
       tracker.flush
       assert_equal 0, collector.counters['knightrider']
-      assert_equal nil, collector.counters['badguys']
+      assert_nil collector.counters['badguys']
     end
 
     def test_flush_should_send_measures_and_timings

--- a/test/unit/collector/aggregator_test.rb
+++ b/test/unit/collector/aggregator_test.rb
@@ -75,7 +75,7 @@ module Librato
 
       def test_return_values
         simple = @agg.timing 'simple', 20
-        assert_equal nil, simple
+        assert_nil simple
 
         timing = @agg.timing 'foo' do
           sleep 0.1

--- a/test/unit/collector/counter_cache_test.rb
+++ b/test/unit/collector/counter_cache_test.rb
@@ -60,8 +60,8 @@ module Librato
         assert_equal 0, cc.fetch(:foo, :source => 'bar')
 
         # sporadic do not
-        assert_equal nil, cc[:baz]
-        assert_equal nil, cc.fetch(:baz, :source => 118)
+        assert_nil cc[:baz]
+        assert_nil cc.fetch(:baz, :source => 118)
 
         # add a different sporadic metric
         cc.increment :bazoom, :sporadic => true
@@ -69,7 +69,7 @@ module Librato
 
         # persist values again
         cc.flush_to(Librato::Metrics::Queue.new)
-        assert_equal nil, cc[:bazoom]
+        assert_nil cc[:bazoom]
       end
 
       def test_flushing

--- a/test/unit/rack/configuration_test.rb
+++ b/test/unit/rack/configuration_test.rb
@@ -55,7 +55,7 @@ module Librato
 
       def test_event_mode
         config = Configuration.new
-        assert_equal nil, config.event_mode
+        assert_nil config.event_mode
 
         config.event_mode = :synchrony
         assert_equal :synchrony, config.event_mode
@@ -67,7 +67,7 @@ module Librato
         # handle invalid
         config2 = Configuration.new
         config2.event_mode = 'fooballoo'
-        assert_equal nil, config2.event_mode
+        assert_nil config2.event_mode
 
         # env detection
         ENV['LIBRATO_EVENT_MODE'] = 'eventmachine'


### PR DESCRIPTION
```assert_equal nil``` will fail in MT6