### PR TITLE
Don't run rake tests with ruby warns

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,6 +33,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
   t.pattern = 'test/**/*_test.rb'
   t.verbose = false
+  t.warning = false
 end
 
 task :default => :test


### PR DESCRIPTION
Default was changed with rake 11, warnings are now on by default. This introduces some noise and while we should probably take a look at some point, some of the decisions are intentional perf trade-offs.

For now just turn warnings back of in the `rake test` definition, to get us back to previous behavior when running with a newer rake.

/cc @chancefeick 