### PR TITLE
Fix deprecation of split integer types in Ruby 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### HEAD
+* Fix deprecation warnings in ruby 2.4 (#57, Ben Radler)
+
 ### Version 1.0.1
 * Fix missing p95 for rack.request.time
 

--- a/lib/librato/collector/counter_cache.rb
+++ b/lib/librato/collector/counter_cache.rb
@@ -74,7 +74,8 @@ module Librato
       #   increment :foo, :source => user.id
       #
       def increment(counter, options={})
-        if options.is_a?(Fixnum)
+        integer_class = 1.class
+        if options.is_a?(integer_class)
           # suppport legacy style
           options = {by: options}
         end

--- a/lib/librato/collector/counter_cache.rb
+++ b/lib/librato/collector/counter_cache.rb
@@ -5,6 +5,7 @@ module Librato
     #
     class CounterCache
       SEPARATOR = '%%'
+      INTEGER_CLASS = 1.class
 
       extend Forwardable
 
@@ -74,8 +75,7 @@ module Librato
       #   increment :foo, :source => user.id
       #
       def increment(counter, options={})
-        integer_class = 1.class
-        if options.is_a?(integer_class)
+        if options.is_a?(INTEGER_CLASS)
           # suppport legacy style
           options = {by: options}
         end


### PR DESCRIPTION
Extends #57 to be slightly more performant by only doing class lookup once.

/cc @chancefeick 