### PR TITLE
Fix license string to remove rubygems warning

### DIFF
--- a/librato-rack.gemspec
+++ b/librato-rack.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Matt Sanders"]
   s.email       = ["matt@librato.com"]
   s.homepage    = "https://github.com/librato/librato-rack"
-  s.license     = 'BSD 3-clause'
+  s.license     = 'BSD-3-Clause'
 
   s.summary     = "Use Librato Metrics with your rack application"
   s.description = "Rack middleware to report key app statistics and custom instrumentation to the Librato Metrics service."


### PR DESCRIPTION
These are now standardized: http://spdx.org/licenses