### PR TITLE
Inherit Tags

### DIFF
--- a/lib/librato/collector.rb
+++ b/lib/librato/collector.rb
@@ -10,6 +10,12 @@ module Librato
     def_delegators :counters, :increment
     def_delegators :aggregate, :measure, :timing
 
+    attr_reader :tags
+
+    def initialize(options={})
+      @tags = options[:tags]
+    end
+
     # access to internal aggregator object
     def aggregate
       @aggregator_cache ||= Aggregator.new(prefix: @prefix)

--- a/lib/librato/collector.rb
+++ b/lib/librato/collector.rb
@@ -23,7 +23,7 @@ module Librato
 
     # access to internal counters object
     def counters
-      @counter_cache ||= CounterCache.new
+      @counter_cache ||= CounterCache.new(default_tags: @tags)
     end
 
     # remove any accumulated but unsent metrics

--- a/lib/librato/collector.rb
+++ b/lib/librato/collector.rb
@@ -18,7 +18,7 @@ module Librato
 
     # access to internal aggregator object
     def aggregate
-      @aggregator_cache ||= Aggregator.new(prefix: @prefix)
+      @aggregator_cache ||= Aggregator.new(prefix: @prefix, default_tags: @tags)
     end
 
     # access to internal counters object

--- a/lib/librato/collector/aggregator.rb
+++ b/lib/librato/collector/aggregator.rb
@@ -96,13 +96,13 @@ module Librato
 
         percentiles = Array(options[:percentile])
         source = options[:source]
-        additional_tags = options[:tags]
-        additional_tags = { source: source } if source && !additional_tags
+        tags_option = options[:tags]
+        tags_option = { source: source } if source && !tags_option
         tags =
-          if @default_tags && additional_tags && options[:inherit_tags]
-            @default_tags.merge(additional_tags)
-          elsif additional_tags
-            additional_tags
+          if @default_tags && tags_option && options[:inherit_tags]
+            @default_tags.merge(tags_option)
+          elsif tags_option
+            tags_option
           else
             @default_tags
           end

--- a/lib/librato/collector/counter_cache.rb
+++ b/lib/librato/collector/counter_cache.rb
@@ -18,7 +18,7 @@ module Librato
         @cache = {}
         @lock = Mutex.new
         @sporadics = Set.new
-        @default_tags = options[:default_tags]
+        @default_tags = options.fetch(:default_tags, {})
       end
 
       # Retrieve the current value for a given metric. This is a short
@@ -87,7 +87,7 @@ module Librato
         tags_option = options[:tags]
         tags_option = { source: source } if source && !tags_option
         tags =
-          if @default_tags && tags_option && options[:inherit_tags]
+          if tags_option && options[:inherit_tags]
             @default_tags.merge(tags_option)
           elsif tags_option
             tags_option

--- a/lib/librato/collector/counter_cache.rb
+++ b/lib/librato/collector/counter_cache.rb
@@ -12,10 +12,13 @@ module Librato
 
       def_delegators :@cache, :empty?
 
-      def initialize
+      attr_reader :default_tags
+
+      def initialize(options={})
         @cache = {}
         @lock = Mutex.new
         @sporadics = Set.new
+        @default_tags = options[:default_tags]
       end
 
       # Retrieve the current value for a given metric. This is a short

--- a/lib/librato/collector/counter_cache.rb
+++ b/lib/librato/collector/counter_cache.rb
@@ -84,13 +84,13 @@ module Librato
         end
         by = options[:by] || 1
         source = options[:source]
-        additional_tags = options[:tags]
-        additional_tags = { source: source } if source && !additional_tags
+        tags_option = options[:tags]
+        tags_option = { source: source } if source && !tags_option
         tags =
-          if @default_tags && additional_tags && options[:inherit_tags]
-            @default_tags.merge(additional_tags)
-          elsif additional_tags
-            additional_tags
+          if @default_tags && tags_option && options[:inherit_tags]
+            @default_tags.merge(tags_option)
+          elsif tags_option
+            tags_option
           else
             @default_tags
           end

--- a/lib/librato/rack.rb
+++ b/lib/librato/rack.rb
@@ -45,14 +45,14 @@ module Librato
 
     RECORD_RACK_STATUS_BODY = <<-'EOS'
       status_tags = { status: status }
-      tracker.increment "rack.request.status", tags: status_tags
-      tracker.timing "rack.request.status.time", duration, tags: status_tags
+      tracker.increment "rack.request.status", tags: status_tags, inherit_tags: true
+      tracker.timing "rack.request.status.time", duration, tags: status_tags, inherit_tags: true
     EOS
 
     RECORD_RACK_METHOD_BODY = <<-'EOS'
       method_tags = { method: http_method.downcase! }
-      tracker.increment "rack.request.method", tags: method_tags
-      tracker.timing "rack.request.method.time", duration, tags: method_tags
+      tracker.increment "rack.request.method", tags: method_tags, inherit_tags: true
+      tracker.timing "rack.request.method.time", duration, tags: method_tags, inherit_tags: true
     EOS
 
     attr_reader :config, :tracker

--- a/lib/librato/rack/tracker.rb
+++ b/lib/librato/rack/tracker.rb
@@ -126,7 +126,7 @@ module Librato
         [collector.counters, collector.aggregate].each do |cache|
           cache.flush_to(queue, preserve: preserve)
         end
-        queue.add 'rack.processes' => 1
+        queue.add 'rack.processes' => { value: 1, tags: tags }
         trace_queued(queue.queued) #if should_log?(:trace)
         queue
       end

--- a/lib/librato/rack/tracker.rb
+++ b/lib/librato/rack/tracker.rb
@@ -38,7 +38,7 @@ module Librato
 
       # primary collector object used by this tracker
       def collector
-        @collector ||= Librato::Collector.new
+        @collector ||= Librato::Collector.new(tags: tags)
       end
 
       # log a deprecation message

--- a/lib/librato/rack/tracker.rb
+++ b/lib/librato/rack/tracker.rb
@@ -14,7 +14,6 @@ module Librato
       def initialize(config)
         @config = config
         collector.prefix = config.prefix
-        collector.aggregate.tags = tags
         config.register_listener(collector)
       end
 

--- a/lib/librato/rack/tracker.rb
+++ b/lib/librato/rack/tracker.rb
@@ -121,7 +121,7 @@ module Librato
       end
 
       def build_flush_queue(collector, preserve=false)
-        queue = ValidatingQueue.new( client: client, tags: tags,
+        queue = ValidatingQueue.new( client: client,
           prefix: config.prefix, skip_measurement_times: true )
         [collector.counters, collector.aggregate].each do |cache|
           cache.flush_to(queue, preserve: preserve)

--- a/test/integration/request_test.rb
+++ b/test/integration/request_test.rb
@@ -27,12 +27,12 @@ class RequestTest < Minitest::Test
     get '/'
     assert last_response.ok?
     assert_equal 1, counters["rack.request.total"][:value]
-    assert_equal 1, counters.fetch("rack.request.status", tags: { status: 200 })[:value]
+    assert_equal 1, counters.fetch("rack.request.status", tags: @tags.merge({ status: 200 }))[:value]
 
     get '/status/204'
     assert_equal 2, counters["rack.request.total"][:value]
-    assert_equal 1, counters.fetch("rack.request.status", tags: { status: 200 })[:value], "should not increment"
-    assert_equal 1, counters.fetch("rack.request.status", tags: { status: 204 })[:value], "should increment"
+    assert_equal 1, counters.fetch("rack.request.status", tags: @tags.merge({ status: 200 }))[:value], "should not increment"
+    assert_equal 1, counters.fetch("rack.request.status", tags: @tags.merge({ status: 204 }))[:value], "should increment"
   end
 
   def test_request_times
@@ -46,19 +46,19 @@ class RequestTest < Minitest::Test
     assert aggregate.fetch("rack.request.time", tags: @tags, percentile: 95) > 0.0
 
     # status specific
-    assert_equal 1, aggregate.fetch("rack.request.status.time", tags: { status: 200 })[:count]
+    assert_equal 1, aggregate.fetch("rack.request.status.time", tags: @tags.merge({ status: 200 }))[:count]
   end
 
   def test_track_http_method_info
     get '/'
 
-    assert_equal 1, counters.fetch("rack.request.method", tags: { method: "GET" })[:value]
-    assert_equal 1, aggregate.fetch("rack.request.method.time", tags: { method: "get" })[:count]
+    assert_equal 1, counters.fetch("rack.request.method", tags: @tags.merge({ method: "GET" }))[:value]
+    assert_equal 1, aggregate.fetch("rack.request.method.time", tags: @tags.merge({ method: "get" }))[:count]
 
     post '/'
 
-    assert_equal 1, counters.fetch("rack.request.method", tags: { method: "POST" })[:value]
-    assert_equal 1, aggregate.fetch("rack.request.method.time", tags: { method: "post" })[:count]
+    assert_equal 1, counters.fetch("rack.request.method", tags: @tags.merge({ method: "POST" }))[:value]
+    assert_equal 1, aggregate.fetch("rack.request.method.time", tags: @tags.merge({ method: "post" }))[:count]
   end
 
   def test_track_exceptions

--- a/test/remote/tracker_test.rb
+++ b/test/remote/tracker_test.rb
@@ -42,7 +42,7 @@ class TrackerRemoteTest < Minitest::Test
       assert metric_names.include?('bar'), 'bar should be present'
 
       # interogate queued payload for expected values
-      assert_equal tags, @queued[:tags]
+      assert_equal [:host], @queued[:measurements].first[:tags].keys
       assert_equal 2, queued('foo')
 
       # custom source

--- a/test/unit/collector/aggregator_test.rb
+++ b/test/unit/collector/aggregator_test.rb
@@ -13,20 +13,19 @@ module Librato
         @agg.timing 'request.time.total', 23.7
         @agg.timing 'request.time.db', 5.3
         @agg.timing 'request.time.total', 64.3
-        measurement = @agg.fetch 'request.time.total', tags: @tags
 
-        assert_equal 2, measurement[:count]
-        assert_equal 88.0, measurement[:sum]
+        assert_equal 2, @agg['request.time.total'][:count]
+        assert_equal 88.0, @agg['request.time.total'][:sum]
       end
 
       def test_block_timing
         @agg.timing 'my.task' do
           sleep 0.2
         end
-        assert_in_delta @agg.fetch('my.task', tags: @tags)[:sum], 200, 50
+        assert_in_delta @agg['my.task'][:sum], 200, 50
 
         @agg.timing('another.task') { sleep 0.1 }
-        assert_in_delta @agg.fetch('another.task', tags: @tags)[:sum], 100, 50
+        assert_in_delta @agg['another.task'][:sum], 100, 50
       end
 
       def test_percentiles
@@ -91,7 +90,7 @@ module Librato
         # tags are kept separate
         @agg.measure 'meaning.of.life', 1
         @agg.measure "meaning.of.life", 42, tags: tags_1
-        assert_equal 1.0, @agg.fetch("meaning.of.life", tags: @tags)[:sum]
+        assert_equal 1.0, @agg.fetch('meaning.of.life')[:sum]
         assert_equal 42.0, @agg.fetch("meaning.of.life", tags: tags_1)[:sum]
 
         tags_2 = { hostname: "mine" }
@@ -152,33 +151,33 @@ module Librato
       end
 
       def test_default_tags
-        default_tags = { a: 1 }
+        default_tags = { queue: 'priority' }
         agg = Aggregator.new(default_tags: default_tags)
-        agg.measure :foo, 1
+        agg.measure 'jobs.queued', 1
 
-        assert_equal 1, agg["foo"][:sum]
-        assert_equal default_tags, agg["foo"][:tags]
+        assert_equal 1, agg['jobs.queued'][:sum]
+        assert_equal default_tags, agg['jobs.queued'][:tags]
       end
 
-      def test_additional_tags
-        default_tags = { a: 1 }
-        additional_tags = { b: 2 }
+      def test_tags_option
+        default_tags = { queue: 'priority' }
+        tags_option = { worker: 'worker.12' }
         agg = Aggregator.new(default_tags: default_tags)
-        agg.measure :foo, 1, tags: additional_tags
+        agg.measure 'jobs.queued', 1, tags: tags_option
 
-        assert_equal 1, agg.fetch("foo", tags: additional_tags)[:sum]
-        assert_equal additional_tags, agg.fetch("foo", tags: additional_tags)[:tags]
+        assert_equal 1, agg.fetch('jobs.queued', tags: tags_option)[:sum]
+        assert_equal tags_option, agg.fetch('jobs.queued', tags: tags_option)[:tags]
       end
 
       def test_inherit_tags
-        default_tags = { a: 1 }
-        additional_tags = { b: 2 }
-        merged_tags = default_tags.merge(additional_tags)
+        default_tags = { queue: 'priority' }
+        tags_option = { worker: 'worker.12' }
+        merged_tags = default_tags.merge(tags_option)
         agg = Aggregator.new(default_tags: default_tags)
-        agg.measure :foo, 1, tags: additional_tags, inherit_tags: true
+        agg.measure 'jobs.queued', 1, tags: tags_option, inherit_tags: true
 
-        assert_equal 1, agg.fetch("foo", tags: merged_tags)[:sum]
-        assert_equal merged_tags, agg.fetch("foo", tags: merged_tags)[:tags]
+        assert_equal 1, agg.fetch('jobs.queued', tags: merged_tags)[:sum]
+        assert_equal merged_tags, agg.fetch('jobs.queued', tags: merged_tags)[:tags]
       end
 
     end

--- a/test/unit/collector/counter_cache_test.rb
+++ b/test/unit/collector/counter_cache_test.rb
@@ -5,7 +5,7 @@ module Librato
     class CounterCacheTest < Minitest::Test
 
       def test_basic_operations
-        cc = CounterCache.new(default_tags: { host: "foobar" })
+        cc = CounterCache.new(default_tags: { host: 'metricsweb-stagevpc-1' })
         cc.increment :foo
         assert_equal 1, cc[:foo][:value]
 
@@ -50,7 +50,7 @@ module Librato
       end
 
       def test_sporadic
-        cc = CounterCache.new(default_tags: { host: "foobar" })
+        cc = CounterCache.new(default_tags: { host: 'metricsweb-stagevpc-1' })
 
         cc.increment :foo
         cc.increment :foo, tags: { hostname: "bar" }
@@ -101,35 +101,33 @@ module Librato
       end
 
       def test_default_tags
-        tags = { a: 1 }
-        cc = CounterCache.new(default_tags: tags)
-        cc.increment :foo
+        default_tags = { host: 'metricsweb-stagevpc-1' }
+        cc = CounterCache.new(default_tags: default_tags)
+        cc.increment 'user.signup'
 
-        assert_equal 1, cc.fetch("foo")[:value]
-        assert_equal tags, cc.fetch("foo")[:tags]
+        assert_equal 1, cc.fetch('user.signup')[:value]
+        assert_equal default_tags, cc.fetch('user.signup')[:tags]
       end
 
-      def test_additional_tags
-        default_tags = { a: 1 }
-        additional_tags = { b: 2 }
+      def test_tags_option
+        default_tags = { host: 'metricsweb-stagevpc-1' }
+        tags_option = { plan: 'developer' }
         cc = CounterCache.new(default_tags: default_tags)
-        cc.increment :foo, tags: additional_tags
-        measurement = cc.fetch("foo", tags: additional_tags)
+        cc.increment 'user.signup', tags: tags_option
 
-        assert_equal 1, measurement[:value]
-        assert_equal additional_tags, measurement[:tags]
+        assert_equal 1, cc.fetch('user.signup', tags: tags_option)[:value]
+        assert_equal tags_option, cc.fetch('user.signup', tags: tags_option)[:tags]
       end
 
       def test_inherit_tags
-        default_tags = { a: 1 }
-        additional_tags = { b: 2 }
-        merged_tags = default_tags.merge(additional_tags)
+        default_tags = { host: 'metricsweb-stagevpc-1' }
+        tags_option = { plan: 'developer' }
+        merged_tags = default_tags.merge(tags_option)
         cc = CounterCache.new(default_tags: default_tags)
-        cc.increment :foo, tags: additional_tags, inherit_tags: true
-        measurement = cc.fetch("foo", tags: merged_tags)
+        cc.increment 'user.signup', tags: tags_option, inherit_tags: true
 
-        assert_equal 1, measurement[:value]
-        assert_equal merged_tags, measurement[:tags]
+        assert_equal 1, cc.fetch('user.signup', tags: merged_tags)[:value]
+        assert_equal merged_tags, cc.fetch('user.signup', tags: merged_tags)[:tags]
       end
 
     end

--- a/test/unit/collector/counter_cache_test.rb
+++ b/test/unit/collector/counter_cache_test.rb
@@ -81,7 +81,8 @@ module Librato
       end
 
       def test_flushing
-        cc = CounterCache.new
+        default_tags = { host: 'metricsweb-stagevpc-1' }
+        cc = CounterCache.new(default_tags: default_tags)
         tags = { hostname: "foobar" }
 
         cc.increment :foo
@@ -92,9 +93,9 @@ module Librato
         q = Librato::Metrics::Queue.new(tags: { region: "us-east-1" })
         cc.flush_to(q)
 
-        expected = Set.new [{:name=>"foo", :value=>1},
+        expected = Set.new [{:name=>"foo", :value=>1, :tags=>default_tags},
                     {:name=>"foo", :value=>4, :tags=>tags},
-                    {:name=>"bar", :value=>2}]
+                    {:name=>"bar", :value=>2, :tags=>default_tags}]
         queued = Set.new(q.measurements)
         queued.each { |hash| hash.delete(:time) }
         assert_equal queued, expected

--- a/test/unit/collector/group_test.rb
+++ b/test/unit/collector/group_test.rb
@@ -9,7 +9,7 @@ module Librato
       end
 
       def test_increment
-        collector = Collector.new
+        collector = Collector.new(tags: { host: "foobar" })
         collector.group 'foo' do |g|
           g.increment :bar
           g.increment :baz, tags: @tags
@@ -19,7 +19,7 @@ module Librato
       end
 
       def test_measure
-        collector = Collector.new
+        collector = Collector.new(tags: { host: "foobar" })
         collector.group 'foo' do |g|
           g.measure :baz, 23, tags: @tags
         end
@@ -27,7 +27,7 @@ module Librato
       end
 
       def test_timing
-        collector = Collector.new
+        collector = Collector.new(tags: { host: "foobar" })
         collector.group 'foo' do |g|
           g.timing :bam, 32.0, tags: @tags
         end
@@ -35,7 +35,7 @@ module Librato
       end
 
       def test_timing_block
-        collector = Collector.new
+        collector = Collector.new(tags: { host: "foobar" })
         collector.group 'foo' do |g|
           g.timing :bak, tags: @tags do
             sleep 0.01
@@ -45,7 +45,7 @@ module Librato
       end
 
       def test_nesting
-        collector = Collector.new
+        collector = Collector.new(tags: { host: "foobar" })
         collector.group 'foo' do |g|
           g.group :bar do |b|
             b.increment :baz, 2

--- a/test/unit/collector/group_test.rb
+++ b/test/unit/collector/group_test.rb
@@ -9,7 +9,7 @@ module Librato
       end
 
       def test_increment
-        collector = Collector.new(tags: { host: "foobar" })
+        collector = Collector.new(tags: { host: 'metricsweb-stagevpc-1' })
         collector.group 'foo' do |g|
           g.increment :bar
           g.increment :baz, tags: @tags
@@ -19,7 +19,7 @@ module Librato
       end
 
       def test_measure
-        collector = Collector.new(tags: { host: "foobar" })
+        collector = Collector.new(tags: { host: 'metricsweb-stagevpc-1' })
         collector.group 'foo' do |g|
           g.measure :baz, 23, tags: @tags
         end
@@ -27,7 +27,7 @@ module Librato
       end
 
       def test_timing
-        collector = Collector.new(tags: { host: "foobar" })
+        collector = Collector.new(tags: { host: 'metricsweb-stagevpc-1' })
         collector.group 'foo' do |g|
           g.timing :bam, 32.0, tags: @tags
         end
@@ -35,7 +35,7 @@ module Librato
       end
 
       def test_timing_block
-        collector = Collector.new(tags: { host: "foobar" })
+        collector = Collector.new(tags: { host: 'metricsweb-stagevpc-1' })
         collector.group 'foo' do |g|
           g.timing :bak, tags: @tags do
             sleep 0.01
@@ -45,7 +45,7 @@ module Librato
       end
 
       def test_nesting
-        collector = Collector.new(tags: { host: "foobar" })
+        collector = Collector.new(tags: { host: 'metricsweb-stagevpc-1' })
         collector.group 'foo' do |g|
           g.group :bar do |b|
             b.increment :baz, 2

--- a/test/unit/collector_test.rb
+++ b/test/unit/collector_test.rb
@@ -10,7 +10,7 @@ module Librato
     end
 
     def test_basic_grouping
-      collector = Collector.new(tags: { host: "foobar" })
+      collector = Collector.new(tags: { host: 'metricsweb-stagevpc-1' })
       tags = { region: "us-east-1" }
       collector.group 'foo' do |g|
         g.increment :bar

--- a/test/unit/collector_test.rb
+++ b/test/unit/collector_test.rb
@@ -10,7 +10,7 @@ module Librato
     end
 
     def test_basic_grouping
-      collector = Collector.new
+      collector = Collector.new(tags: { host: "foobar" })
       tags = { region: "us-east-1" }
       collector.group 'foo' do |g|
         g.increment :bar


### PR DESCRIPTION
Add support to inherit tags for custom instrumentation. Here are a few scenarios:

**Default Tags**: When no `:tags` option is set, use default tags supplied by `Configuration`. When no config is set, `:host` is auto-detected.

```ruby
Librato.increment 'user.signup'
# => {:host=>"ip-10-0-0-4.ec2.internal"}
```

**Overriding Default Tags**: When `:tags` option is set, use `:tags` value instead. Default tags **are not included**.
```ruby
Librato.increment 'user.signup', tags: { plan: 'developer' }
#=> {:plan=>"developer"}
```

**Inheriting Default Tags**: When `:tags` option is set with `:inherit_tags` option, merges `:tags` value with default tags. 
```ruby
Librato.increment 'user.signup', tags: { plan: 'developer' }, inherit_tags: true
# => {:host=>"ip-10-0-0-4.ec2.internal", :plan=>"developer"}
```

Merge into https://github.com/librato/librato-rack/pull/54.