### PR TITLE
Remove rubinius support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.4.0
   - jruby-19mode
   - ruby-head
-  - rbx
 
 before_install:
   - gem update bundler

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,6 @@ gem 'eventmachine'
 gem 'em-synchrony'
 
 platforms :rbx do
-  gem 'rubysl', '~> 2.0'
+  gem 'rubysl', '~> 2.0', '>= 2.0.13'
   gem 'rubinius-developer_tools'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,3 @@ gem 'rake'
 # used for variable timer modes
 gem 'eventmachine'
 gem 'em-synchrony'
-
-platforms :rbx do
-  gem 'rubysl', '~> 2.0', '>= 2.0.13'
-  gem 'rubinius-developer_tools'
-end


### PR DESCRIPTION
Edit: Remove rubinius support. Fix Ruby 1.9.3 builds.