### PR TITLE
ensure rack.request.queue.time metric is not negative

### DIFF
--- a/lib/librato/rack.rb
+++ b/lib/librato/rack.rb
@@ -152,9 +152,11 @@ module Librato
             case queue_start.length
             when 16 # microseconds
               wait = ((Time.now.to_f * 1000000).to_i - queue_start.to_i) / 1000.0
+              wait = 0 if wait < 0 # make up for potential time drift between the routing server and the application server
               tracker.timing 'rack.request.queue.time', wait, percentile: 95
             when 13 # milliseconds
               wait = (Time.now.to_f * 1000).to_i - queue_start.to_i
+              wait = 0 if wait < 0 # make up for potential time drift between the routing server and the application server
               tracker.timing 'rack.request.queue.time', wait, percentile: 95
             end
           end

--- a/test/apps/queue_wait.ru
+++ b/test/apps/queue_wait.ru
@@ -26,6 +26,9 @@ class QueueWait
     when '/with_period'
       env['HTTP_X_REQUEST_START'] = "%10.3f" % Time.now
       sleep 0.025
+    when '/with_time_drift'
+      env['HTTP_X_REQUEST_START'] = ((Time.now.to_f * 1000).to_i + 10).to_s # 10s in the future
+      sleep 0.005
     end
     @app.call(env)
   end

--- a/test/integration/queue_wait_test.rb
+++ b/test/integration/queue_wait_test.rb
@@ -62,6 +62,25 @@ class QueueWaitTest < Minitest::Test
     assert_in_delta 25, aggregate["rack.request.queue.time"][:sum], delta
   end
 
+  def test_with_period
+    get '/with_period'
+
+    # give jruby a bit more time since it can be slow
+    delta = defined?(JRUBY_VERSION) ? 10 : 6
+    assert_equal 1, aggregate["rack.request.queue.time"][:count],
+      'should track total queue time'
+    assert_in_delta 25, aggregate["rack.request.queue.time"][:sum], delta
+  end
+
+  def test_with_time_drift
+    get '/with_time_drift'
+
+    # puts "milli: #{aggregate["rack.request.queue.time"].inspect}"
+    assert_equal 1, aggregate["rack.request.queue.time"][:count],
+      'should track total queue time'
+    assert_in_delta 0, aggregate["rack.request.queue.time"][:sum], 4
+  end
+
   private
 
   def aggregate


### PR DESCRIPTION
This is related to this issue: https://github.com/librato/librato-rack/issues/66