### PR TITLE
Validating Queue

### DIFF
--- a/lib/librato/rack/validating_queue.rb
+++ b/lib/librato/rack/validating_queue.rb
@@ -8,12 +8,18 @@ module Librato
       DEFAULT_TAGS_LIMIT = 4
       METRIC_NAME_REGEX = /\A[-.:_\w]{1,255}\z/
       TAGS_KEY_REGEX = /\A[-.:_\w]{1,64}\z/
-      TAGS_VALUE_REGEX = /\A[-.:_\w]{1,256}\z/
+      TAGS_VALUE_REGEX = /\A[-.:_\w\s]{1,255}\z/
 
       attr_accessor :logger
 
-      # screen all measurements for validity before sending
       def submit
+        validate_measurements
+
+        super
+      end
+
+      # screen all measurements for validity before sending
+      def validate_measurements
         @queued[:measurements].delete_if do |entry|
           name = entry[:name].to_s
           tags = entry[:tags]
@@ -27,8 +33,6 @@ module Librato
             false # preserve
           end
         end
-
-        super
       end
 
       private

--- a/test/unit/rack/validating_queue_test.rb
+++ b/test/unit/rack/validating_queue_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+module Librato
+  class Rack
+    class ValidatingQueueTest < Minitest::Test
+      def setup
+        @queue = ValidatingQueue.new
+      end
+
+      def test_valid_metric_name_tag_name_tag_value
+        @queue.add valid_metric_name: {
+          value: rand(100),
+          tags: { valid_tag_name: 'valid_tag_value' }
+        }
+        @queue.validate_measurements
+        refute_empty @queue.queued[:measurements]
+      end
+
+      def test_valid_tag_value_with_whitespace
+        @queue.add valid_metric_name: {
+          value: rand(100),
+          tags: { valid_tag_name: 'valid tag value' }
+        }
+        @queue.validate_measurements
+        refute_empty @queue.queued[:measurements]
+      end
+
+      def test_invalid_metric_name
+        @queue.add 'invalid metric name' => {
+          value: rand(100),
+          tags: { valid_tag_name: 'valid_tag_value' }
+        }
+        @queue.validate_measurements
+        assert_empty @queue.queued[:measurements]
+      end
+
+      def test_invalid_tag_name
+        @queue.add valid_metric_name: {
+          value: rand(100),
+          tags: { 'invalid_tag_name!' => 'valid_tag_value' }
+        }
+        @queue.validate_measurements
+        assert_empty @queue.queued[:measurements]
+      end
+
+      def test_invalid_tag_value
+        @queue.add valid_metric_name: {
+          value: rand(100),
+          tags: { valid_tag_name: 'invalid_tag_value!' }
+        }
+        @queue.validate_measurements
+        assert_empty @queue.queued[:measurements]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Tag value restrictions have changed for general availability. Introduce the following changes:

* Update `TAGS_VALUE_REGEX` to allow whitespace
* Reduce `TAGS_VALUE_REGEX` character limit to 255
* Add `#validate_measurements` method
* Add tests for each context

Please refer to [API docs](https://www.librato.com/docs/api/#create-a-measurement) for most up-to-date information.

cc @nextmat 