### PR TITLE
only include `rack.processes` if `rack` suite enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ use Librato::Rack, :config => config
 
 The metrics recorded by `librato-rack` are organized into named metric suites that can be selectively enabled/disabled:
 
-* `rack`: The `rack.request.total`, `rack.request.time`, `rack.request.slow`, and `rack.request.queue.time` metrics
+* `rack`: The `rack.request.total`, `rack.request.time`, `rack.request.slow`, `rack.request.queue.time`, and `rack.processes` metrics
 * `rack_status`: `rack.request.status` metric with `status` tag name and HTTP status code tag value, e.g. `status=200`
 * `rack_method`: `rack.request.method` metric with `method` tag name and HTTP method tag value, e.g. `method=POST`
 

--- a/lib/librato/rack/tracker.rb
+++ b/lib/librato/rack/tracker.rb
@@ -125,7 +125,9 @@ module Librato
         [collector.counters, collector.aggregate].each do |cache|
           cache.flush_to(queue, preserve: preserve)
         end
-        queue.add 'rack.processes' => { value: 1, tags: tags }
+        if suite_enabled?(:rack)
+          queue.add 'rack.processes' => { value: 1, tags: tags }
+        end
         trace_queued(queue.queued) #if should_log?(:trace)
         queue
       end


### PR DESCRIPTION
Hi there!

I opened an issue for this about a month ago (https://github.com/librato/librato-rack/issues/74), and now I'd like to propose a change that will make the `rack.processes` metric a part of the `rack` suite.

This PR includes the diff for that change. I did not add any tests because I didn't see any equivalent tests. I'd be happy to add one if you deem it necessary and have some guidance on how you'd like to see that tested.

Thanks for your time!