### PR TITLE
Avoid changing the http_method

### DIFF
--- a/lib/librato/rack.rb
+++ b/lib/librato/rack.rb
@@ -50,7 +50,7 @@ module Librato
     EOS
 
     RECORD_RACK_METHOD_BODY = <<-'EOS'
-      method_tags = { method: http_method.downcase! }
+      method_tags = { method: http_method.downcase }
       tracker.increment "rack.request.method", tags: method_tags, inherit_tags: true
       tracker.timing "rack.request.method.time", duration, tags: method_tags, inherit_tags: true
     EOS


### PR DESCRIPTION
From time to time, we see some `FrozenError` coming from this piece of code.

This will avoid modifying the `http_method` directly and instead create a copy