### PR TITLE
Change downcase! to downcase to prevent mutation

### DIFF
--- a/lib/librato/rack.rb
+++ b/lib/librato/rack.rb
@@ -50,7 +50,7 @@ module Librato
     EOS
 
     RECORD_RACK_METHOD_BODY = <<-'EOS'
-      method_tags = { method: http_method.downcase! }
+      method_tags = { method: http_method.downcase }
       tracker.increment "rack.request.method", tags: method_tags, inherit_tags: true
       tracker.timing "rack.request.method.time", duration, tags: method_tags, inherit_tags: true
     EOS

--- a/test/integration/request_test.rb
+++ b/test/integration/request_test.rb
@@ -61,6 +61,13 @@ class RequestTest < Minitest::Test
     assert_equal 1, aggregate.fetch("rack.request.method.time", tags: @tags.merge({ method: "post" }))[:count]
   end
 
+  def test_request_method_not_mutated
+    get '/', {}, {'REQUEST_METHOD' => "GET".freeze}
+
+    assert_equal 1, counters.fetch("rack.request.method", tags: @tags.merge({ method: "GET" }))[:value]
+    assert_equal 1, aggregate.fetch("rack.request.method.time", tags: @tags.merge({ method: "get" }))[:count]
+  end
+
   def test_track_exceptions
     begin
       get '/exception'


### PR DESCRIPTION
After we upgraded from Rails 5.1.1 to Rails 5.2.0 we started seeing the following error in the logs.  These errors happen periodically and prevent the request from being successfully completed.  We are on version `1.1.0` because we do not have tagged sources yet, is there a branch that I can push a fix to for the `1.x` series?

```
RuntimeError: can't modify frozen String
File "(eval)" line 15 in downcase!
File "(eval)" line 15 in block (2 levels) in record_request_metrics
File "/app/vendor/bundle/ruby/2.3.0/gems/librato-rack-1.1.0/lib/librato/collector/group.rb" line 13 in group
File "(eval)" line 14 in block in record_request_metrics
File "/app/vendor/bundle/ruby/2.3.0/gems/librato-rack-1.1.0/lib/librato/collector.rb" line 32 in group
File "/app/vendor/ruby-2.3.7/lib/ruby/2.3.0/forwardable.rb" line 202 in group
File "(eval)" line 3 in record_request_metrics
File "/app/vendor/bundle/ruby/2.3.0/gems/librato-rack-1.1.0/lib/librato/rack.rb" line 82 in call
```

