### PR TITLE
Update tag value validation

### DIFF
--- a/lib/librato/rack/validating_queue.rb
+++ b/lib/librato/rack/validating_queue.rb
@@ -8,7 +8,7 @@ module Librato
       DEFAULT_TAGS_LIMIT = 4
       METRIC_NAME_REGEX = /\A[-.:_\w]{1,255}\z/
       TAGS_KEY_REGEX = /\A[-.:_\w]{1,64}\z/
-      TAGS_VALUE_REGEX = /\A[-.:_\\\/\w ]{1,255}\z/
+      TAGS_VALUE_REGEX = /\A[-.:_?\\\/\w ]{1,255}\z/
 
       attr_accessor :logger
 

--- a/lib/librato/rack/validating_queue.rb
+++ b/lib/librato/rack/validating_queue.rb
@@ -8,7 +8,7 @@ module Librato
       DEFAULT_TAGS_LIMIT = 4
       METRIC_NAME_REGEX = /\A[-.:_\w]{1,255}\z/
       TAGS_KEY_REGEX = /\A[-.:_\w]{1,64}\z/
-      TAGS_VALUE_REGEX = /\A[-.:_\w\s]{1,255}\z/
+      TAGS_VALUE_REGEX = /\A[-.:_\\\/\w ]{1,255}\z/
 
       attr_accessor :logger
 

--- a/test/unit/rack/validating_queue_test.rb
+++ b/test/unit/rack/validating_queue_test.rb
@@ -34,6 +34,15 @@ module Librato
         refute_empty @queue.queued[:measurements]
       end
 
+      def test_valid_tag_value_with_question_mark
+        @queue.add valid_metric_name: {
+          value: rand(100),
+          tags: { valid_tag_name: 'valid_tag_value?' }
+        }
+        @queue.validate_measurements
+        refute_empty @queue.queued[:measurements]
+      end
+
       def test_invalid_metric_name
         @queue.add 'invalid metric name' => {
           value: rand(100),

--- a/test/unit/rack/validating_queue_test.rb
+++ b/test/unit/rack/validating_queue_test.rb
@@ -25,6 +25,15 @@ module Librato
         refute_empty @queue.queued[:measurements]
       end
 
+      def test_valid_tag_value_with_slashes
+        @queue.add valid_metric_name: {
+          value: rand(100),
+          tags: { valid_tag_name: 'valid/tag/value' }
+        }
+        @queue.validate_measurements
+        refute_empty @queue.queued[:measurements]
+      end
+
       def test_invalid_metric_name
         @queue.add 'invalid metric name' => {
           value: rand(100),


### PR DESCRIPTION
The metrics API has different validation for tag values, namely in that
it supports slashes.

This updates `TAGS_VALUE_REGEX` to match the [restrictions in the HTTP
API documentation](https://www.librato.com/docs/api/#rate-limiting),
along with a test for this case.